### PR TITLE
[Backtracing][Runtime][Darwin] Add code to trigger the external backtracer.

### DIFF
--- a/include/swift/Runtime/Backtrace.h
+++ b/include/swift/Runtime/Backtrace.h
@@ -1,0 +1,117 @@
+//===--- Backtrace.cpp - Swift crash catching and backtracing support ---- ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions relating to backtracing.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_BACKTRACE_H
+#define SWIFT_RUNTIME_BACKTRACE_H
+
+#include "swift/Runtime/Config.h"
+
+#include "swift/shims/Visibility.h"
+#include "swift/shims/_SwiftBacktracing.h"
+
+#include <inttypes.h>
+
+#ifdef __cplusplus
+namespace swift {
+namespace runtime {
+namespace backtrace {
+#endif
+
+#ifdef _WIN32
+typedef wchar_t ArgChar;
+typedef DWORD ErrorCode;
+#else
+typedef char ArgChar;
+typedef int ErrorCode;
+#endif
+
+SWIFT_RUNTIME_STDLIB_INTERNAL ErrorCode _swift_installCrashHandler();
+
+SWIFT_RUNTIME_STDLIB_INTERNAL bool _swift_spawnBacktracer(const ArgChar * const *argv);
+
+enum class UnwindAlgorithm {
+  Auto = 0,
+  Fast = 1,
+  Precise = 2
+};
+
+enum class OnOffTty {
+  Off = 0,
+  On = 1,
+  TTY = 2
+};
+
+enum class Preset {
+  Auto = -1,
+  Friendly = 0,
+  Medium = 1,
+  Full = 2
+};
+
+enum class ThreadsToShow {
+  Preset = -1,
+  All = 0,
+  Crashed = 1
+};
+
+enum class RegistersToShow {
+  Preset = -1,
+  None = 0,
+  All = 1,
+  Crashed = 2
+};
+
+enum class ImagesToShow {
+  Preset = -1,
+  None = 0,
+  All = 1,
+  Mentioned = 2
+};
+
+enum class SanitizePaths {
+  Preset = -1,
+  Off = 0,
+  On = 1
+};
+
+struct BacktraceSettings {
+  UnwindAlgorithm  algorithm;
+  OnOffTty         enabled;
+  bool             demangle;
+  OnOffTty         interactive;
+  OnOffTty         color;
+  unsigned         timeout;
+  ThreadsToShow    threads;
+  RegistersToShow  registers;
+  ImagesToShow     images;
+  unsigned         limit;
+  unsigned         top;
+  SanitizePaths    sanitize;
+  Preset           preset;
+  const char      *swiftBacktracePath;
+};
+
+SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings;
+
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift) bool _swift_isThunkFunction(const char *mangledName);
+
+#ifdef __cplusplus
+} // namespace backtrace
+} // namespace runtime
+} // namespace swift
+#endif
+
+#endif // SWIFT_RUNTIME_BACKTRACE_H

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -481,6 +481,34 @@ swift_auth_code(T value, unsigned extra) {
 #endif
 }
 
+/// Does this platform support backtrace-on-crash?
+#ifdef __APPLE__
+#  include <TargetConditionals.h>
+#  if TARGET_OS_OSX
+#    define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 1
+#    define SWIFT_BACKTRACE_SECTION "__DATA,swift5_backtrace"
+#  else
+#    define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 0
+#  endif
+#elif defined(_WIN32)
+#  define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 0
+#  define SWIFT_BACKTRACE_SECTION ".sw5bckt"
+#elif defined(__linux__)
+#  define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 0
+#  define SWIFT_BACKTRACE_SECTION "swift5_backtrace"
+#else
+#  define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 0
+#endif
+
+/// What is the system page size?
+#if defined(__APPLE__) && defined(__arm64__)
+  // Apple Silicon systems use a 16KB page size
+  #define SWIFT_PAGE_SIZE 16384
+#else
+  // Everything else uses 4KB pages
+  #define SWIFT_PAGE_SIZE 4096
+#endif
+
 #endif
 
 #endif // SWIFT_RUNTIME_CONFIG_H

--- a/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
@@ -1,0 +1,39 @@
+//===--- _SwiftBacktracing.h - Swift Backtracing Support --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines types and support functions for the Swift backtracing code.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BACKTRACING_H
+#define SWIFT_BACKTRACING_H
+
+#include <inttypes.h>
+
+#ifdef __cplusplus
+namespace swift {
+extern "C" {
+#endif
+
+struct CrashInfo {
+  uint64_t crashing_thread;
+  uint64_t signal;
+  uint64_t fault_address;
+  uint64_t mctx;
+};
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace swift
+#endif
+
+#endif // SWIFT_BACKTRACING_H

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -1,0 +1,755 @@
+//===--- Backtrace.cpp - Swift crash catching and backtracing support ---- ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Crash catching and backtracing support routines.
+//
+//===----------------------------------------------------------------------===//
+
+#include <type_traits>
+
+#include "llvm/ADT/StringRef.h"
+
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/Backtrace.h"
+#include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Paths.h"
+#include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/Win32.h"
+
+#include "swift/Demangling/Demangler.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <spawn.h>
+#include <unistd.h>
+#endif
+
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+
+#define DEBUG_BACKTRACING_SETTINGS 0
+
+#ifndef lengthof
+#define lengthof(x) (sizeof(x) / sizeof(x[0]))
+#endif
+
+using namespace swift::runtime::backtrace;
+
+namespace swift {
+namespace runtime {
+namespace backtrace {
+
+SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings = {
+  UnwindAlgorithm::Auto,
+
+  // enabled
+#if TARGET_OS_OSX
+  OnOffTty::TTY,
+#elif 0 // defined(__linux__) || defined(_WIN32)
+  OnOffTty::On,
+#else
+  OnOffTty::Off,
+#endif
+
+  // demangle
+  true,
+
+  // interactive
+#if TARGET_OS_OSX // || defined(__linux__) || defined(_WIN32)
+  OnOffTty::TTY,
+#else
+  OnOffTty::Off,
+#endif
+
+  // color
+  OnOffTty::TTY,
+
+  // timeout
+  30,
+
+  // threads
+  ThreadsToShow::Preset,
+
+  // registers
+  RegistersToShow::Preset,
+
+  // images
+  ImagesToShow::Preset,
+
+  // limit
+  64,
+
+  // top
+  16,
+
+  // sanitize,
+  SanitizePaths::Preset,
+
+  // preset
+  Preset::Auto,
+
+  // swiftBacktracePath
+  NULL,
+};
+
+}
+}
+}
+
+namespace {
+
+class BacktraceInitializer {
+public:
+  BacktraceInitializer();
+};
+
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
+
+BacktraceInitializer backtraceInitializer;
+
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
+
+#if TARGET_OS_OSX
+posix_spawnattr_t backtraceSpawnAttrs;
+posix_spawn_file_actions_t backtraceFileActions;
+#endif
+
+#if SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
+
+// We need swiftBacktracePath to be aligned on a page boundary, and it also
+// needs to be a multiple of the system page size.
+#define SWIFT_BACKTRACE_BUFFER_SIZE 16384
+
+static_assert((SWIFT_BACKTRACE_BUFFER_SIZE % SWIFT_PAGE_SIZE) == 0,
+              "The backtrace path buffer must be a multiple of the system "
+              "page size.  If it isn't, you'll get weird crashes in other "
+              "code because we'll protect more than just the buffer.");
+
+// The same goes for swiftBacktraceEnvironment
+#define SWIFT_BACKTRACE_ENVIRONMENT_SIZE 32768
+
+static_assert((SWIFT_BACKTRACE_ENVIRONMENT_SIZE % SWIFT_PAGE_SIZE) == 0,
+              "The environment buffer must be a multiple of the system "
+              "page size.  If it isn't, you'll get weird crashes in other "
+              "code because we'll protect more than just the buffer.");
+
+#if _WIN32
+#pragma section(SWIFT_BACKTRACE_SECTION, read, write)
+__declspec(allocate(SWIFT_BACKTRACE_SECTION)) WCHAR swiftBacktracePath[SWIFT_BACKTRACE_BUFFER_SIZE];
+__declspec(allocate(SWIFT_BACKTRACE_SECTION)) CHAR swiftBacktraceEnv[SWIFT_BACKTRACE_ENVIRONMENT_SIZE];
+#elif defined(__linux__) || TARGET_OS_OSX
+char swiftBacktracePath[SWIFT_BACKTRACE_BUFFER_SIZE] __attribute__((section(SWIFT_BACKTRACE_SECTION), aligned(SWIFT_PAGE_SIZE)));
+char swiftBacktraceEnv[SWIFT_BACKTRACE_ENVIRONMENT_SIZE] __attribute__((section(SWIFT_BACKTRACE_SECTION), aligned(SWIFT_PAGE_SIZE)));
+#endif
+
+void _swift_backtraceSetupEnvironment();
+
+bool isStdoutATty()
+{
+#ifndef _WIN32
+  return isatty(STDOUT_FILENO);
+#else
+  DWORD dwMode;
+  return GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &dwMode);
+#endif
+}
+
+bool isStdinATty()
+{
+#ifndef _WIN32
+  return isatty(STDIN_FILENO);
+#else
+  DWORD dwMode;
+  return GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &dwMode);
+#endif
+}
+
+#endif // SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
+
+void _swift_processBacktracingSetting(llvm::StringRef key, llvm::StringRef value);
+void _swift_parseBacktracingSettings(const char *);
+
+#if DEBUG_BACKTRACING_SETTINGS
+const char *algorithmToString(UnwindAlgorithm algorithm) {
+  switch (algorithm) {
+  case UnwindAlgorithm::Auto: return "Auto";
+  case UnwindAlgorithm::Fast: return "Fast";
+  case UnwindAlgorithm::Precise: return "Precise";
+  }
+}
+
+const char *onOffTtyToString(OnOffTty oot) {
+  switch (oot) {
+  case OnOffTty::On: return "On";
+  case OnOffTty::Off: return "Off";
+  case OnOffTty::TTY: return "TTY";
+  }
+}
+
+const char *boolToString(bool b) {
+  return b ? "true" : "false";
+}
+
+const char *presetToString(Preset preset) {
+  switch (preset) {
+  case Preset::Auto: return "Auto";
+  case Preset::Friendly: return "Friendly";
+  case Preset::Medium: return "Medium";
+  case Preset::Full: return Full;
+  }
+}
+#endif
+
+} // namespace
+
+BacktraceInitializer::BacktraceInitializer() {
+  const char *backtracing = swift::runtime::environment::SWIFT_BACKTRACE();
+
+  if (backtracing)
+    _swift_parseBacktracingSettings(backtracing);
+
+#if TARGET_OS_OSX
+  // Make sure that we don't pass on setuid privileges, and that all fds
+  // are closed except for stdin/stdout/stderr.
+  posix_spawnattr_init(&backtraceSpawnAttrs);
+  posix_spawnattr_setflags(&backtraceSpawnAttrs,
+                           POSIX_SPAWN_RESETIDS | POSIX_SPAWN_CLOEXEC_DEFAULT);
+
+  posix_spawn_file_actions_init(&backtraceFileActions);
+  posix_spawn_file_actions_addinherit_np(&backtraceFileActions, STDIN_FILENO);
+  posix_spawn_file_actions_addinherit_np(&backtraceFileActions, STDOUT_FILENO);
+  posix_spawn_file_actions_addinherit_np(&backtraceFileActions, STDERR_FILENO);
+#endif
+
+#if !SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
+  if (_swift_backtraceSettings.enabled != OnOffTty::Off) {
+    swift::warning(0,
+                   "swift runtime: backtrace-on-crash is not supported on "
+                   "this platform.\n");
+    _swift_backtraceSettings.enabled = OnOffTty::Off;
+  }
+#else
+  if (_swift_backtraceSettings.enabled == OnOffTty::TTY)
+    _swift_backtraceSettings.enabled =
+      isStdoutATty() ? OnOffTty::On : OnOffTty::Off;
+
+  if (_swift_backtraceSettings.interactive == OnOffTty::TTY) {
+    _swift_backtraceSettings.interactive =
+      (isStdoutATty() && isStdinATty()) ? OnOffTty::On : OnOffTty::Off;
+  }
+
+  if (_swift_backtraceSettings.color == OnOffTty::TTY)
+    _swift_backtraceSettings.color =
+      isStdoutATty() ? OnOffTty::On : OnOffTty::Off;
+
+  if (_swift_backtraceSettings.preset == Preset::Auto) {
+    if (_swift_backtraceSettings.interactive == OnOffTty::On)
+      _swift_backtraceSettings.preset = Preset::Friendly;
+    else
+      _swift_backtraceSettings.preset = Preset::Full;
+  }
+
+  if (_swift_backtraceSettings.enabled == OnOffTty::On
+      && !_swift_backtraceSettings.swiftBacktracePath) {
+    _swift_backtraceSettings.swiftBacktracePath
+      = swift_getAuxiliaryExecutablePath("swift-backtrace");
+
+    if (!_swift_backtraceSettings.swiftBacktracePath) {
+      swift::warning(0,
+                     "swift runtime: unable to locate swift-backtrace; "
+                     "disabling backtracing.\n");
+      _swift_backtraceSettings.enabled = OnOffTty::Off;
+    }
+  }
+
+  if (_swift_backtraceSettings.enabled == OnOffTty::On) {
+    // Copy the path to swift-backtrace into swiftBacktracePath, then write
+    // protect it so that it can't be overwritten easily at runtime.  We do
+    // this to avoid creating a massive security hole that would allow an
+    // attacker to overwrite the path and then cause a crash to get us to
+    // execute an arbitrary file.
+
+#if _WIN32
+    if (_swift_backtraceSettings.algorithm == UnwindAlgorithm::Auto)
+      _swift_backtraceSettings.algorithm = UnwindAlgorithm::Precise;
+
+    int len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                    _swift_backtraceSettings.swiftBacktracePath, -1,
+                                    swiftBacktracePath,
+                                    SWIFT_BACKTRACE_BUFFER_SIZE);
+    if (!len) {
+      swift::warning(0,
+                     "swift runtime: unable to convert path to "
+                     "swift-backtrace: %08lx; disabling backtracing.\n",
+                     ::GetLastError());
+      _swift_backtraceSettings.enabled = OnOffTty::Off;
+    } else if (!VirtualProtect(swiftBacktracePath,
+                               sizeof(swiftBacktracePath),
+                               PAGE_READONLY,
+                               NULL)) {
+      swift::warning(0,
+                     "swift runtime: unable to protect path to "
+                     "swift-backtrace: %08lx; disabling backtracing.\n",
+                     ::GetLastError());
+      _swift_backtraceSettings.enabled = OnOffTty::Off;
+    }
+
+    _swift_backtraceSetupEnvironment();
+
+    if (!VirtualProtect(swiftBacktraceEnv,
+                        sizeof(swiftBacktraceEnv),
+                        PAGE_READONLY,
+                        NULL)) {
+      swift::warning(0,
+                     "swift runtime: unable to protect environment "
+                     "for swift-backtrace: %08lx; disabling backtracing.\n",
+                     ::GetLastError());
+      _swift_backtraceSettings.enabled = OnOffTty::Off;
+    }
+#else
+    if (_swift_backtraceSettings.algorithm == UnwindAlgorithm::Auto)
+      _swift_backtraceSettings.algorithm = UnwindAlgorithm::Precise;
+
+    size_t len = strlen(_swift_backtraceSettings.swiftBacktracePath);
+    if (len > SWIFT_BACKTRACE_BUFFER_SIZE - 1) {
+      swift::warning(0,
+                     "swift runtime: path to swift-backtrace is too long; "
+                     "disabling backtracing.\n");
+      _swift_backtraceSettings.enabled = OnOffTty::Off;
+    } else {
+      memcpy(swiftBacktracePath,
+             _swift_backtraceSettings.swiftBacktracePath,
+             len + 1);
+
+      if (mprotect(swiftBacktracePath,
+                   sizeof(swiftBacktracePath),
+                   PROT_READ) < 0) {
+        swift::warning(0,
+                       "swift runtime: unable to protect path to "
+                       "swift-backtrace at %p: %d; disabling backtracing.\n",
+                       swiftBacktracePath,
+                       errno);
+        _swift_backtraceSettings.enabled = OnOffTty::Off;
+      }
+    }
+
+    _swift_backtraceSetupEnvironment();
+
+    if (mprotect(swiftBacktraceEnv,
+                 sizeof(swiftBacktraceEnv),
+                 PROT_READ) < 0) {
+        swift::warning(0,
+                       "swift runtime: unable to protect environment for "
+                       "swift-backtrace at %p: %d; disabling backtracing.\n",
+                       swiftBacktraceEnv,
+                       errno);
+        _swift_backtraceSettings.enabled = OnOffTty::Off;
+    }
+#endif
+  }
+
+  if (_swift_backtraceSettings.enabled == OnOffTty::On) {
+    ErrorCode err = _swift_installCrashHandler();
+    if (err != 0) {
+      swift::warning(0,
+                     "swift runtime: crash handler installation failed; "
+                     "disabling backtracing.\n");
+    }
+  }
+#endif
+
+#if DEBUG_BACKTRACING_SETTINGS
+  printf("\nBACKTRACING SETTINGS\n"
+         "\n"
+         "algorithm: %s\n"
+         "enabled: %s\n"
+         "demangle: %s\n"
+         "interactive: %s\n"
+         "color: %s\n"
+         "timeout: %u\n"
+         "preset: %s\n"
+         "swiftBacktracePath: %s\n",
+         algorithmToString(_swift_backtraceSettings.algorithm),
+         onOffTtyToString(_swift_backtraceSettings.enabled),
+         boolToString(_swift_backtraceSettings.demangle),
+         onOffTtyToString(_swift_backtraceSettings.interactive),
+         onOffTtyToString(_swift_backtraceSettings.color),
+         _swift_backtraceSettings.timeout,
+         presetToString(_swift_backtraceSettings.preset),
+         swiftBacktracePath);
+
+  printf("\nBACKTRACING ENV\n");
+
+  const char *ptr = swiftBacktraceEnv;
+  while (*ptr) {
+    size_t len = std::strlen(ptr);
+    printf("%s\n", ptr);
+    ptr += len + 1;
+  }
+  printf("\n");
+#endif
+}
+
+namespace {
+
+OnOffTty
+parseOnOffTty(llvm::StringRef value)
+{
+  if (value.equals_insensitive("on")
+      || value.equals_insensitive("true")
+      || value.equals_insensitive("yes")
+      || value.equals_insensitive("y")
+      || value.equals_insensitive("t")
+      || value.equals_insensitive("1"))
+    return OnOffTty::On;
+  if (value.equals_insensitive("tty")
+      || value.equals_insensitive("auto"))
+    return OnOffTty::TTY;
+  return OnOffTty::Off;
+}
+
+bool
+parseBoolean(llvm::StringRef value)
+{
+  return (value.equals_insensitive("on")
+          || value.equals_insensitive("true")
+          || value.equals_insensitive("yes")
+          || value.equals_insensitive("y")
+          || value.equals_insensitive("t")
+          || value.equals_insensitive("1"));
+}
+
+void
+_swift_processBacktracingSetting(llvm::StringRef key,
+                                 llvm::StringRef value)
+
+{
+  if (key.equals_insensitive("enable")) {
+    _swift_backtraceSettings.enabled = parseOnOffTty(value);
+  } else if (key.equals_insensitive("demangle")) {
+    _swift_backtraceSettings.demangle = parseBoolean(value);
+  } else if (key.equals_insensitive("interactive")) {
+    _swift_backtraceSettings.interactive = parseOnOffTty(value);
+  } else if (key.equals_insensitive("color")) {
+    _swift_backtraceSettings.color = parseOnOffTty(value);
+  } else if (key.equals_insensitive("timeout")) {
+    int count;
+    llvm::StringRef valueCopy = value;
+
+    if (value.equals_insensitive("none")) {
+      _swift_backtraceSettings.timeout = 0;
+    } else if (!valueCopy.consumeInteger(0, count)) {
+      // Yes, consumeInteger() really does return *false* for success
+      llvm::StringRef unit = valueCopy.trim();
+
+      if (unit.empty()
+          || unit.equals_insensitive("s")
+          || unit.equals_insensitive("seconds"))
+        _swift_backtraceSettings.timeout = count;
+      else if (unit.equals_insensitive("m")
+               || unit.equals_insensitive("minutes"))
+        _swift_backtraceSettings.timeout = count * 60;
+      else if (unit.equals_insensitive("h")
+               || unit.equals_insensitive("hours"))
+        _swift_backtraceSettings.timeout = count * 3600;
+
+      if (_swift_backtraceSettings.timeout < 0) {
+        swift::warning(0,
+                       "swift runtime: bad backtracing timeout %ds\n",
+                       _swift_backtraceSettings.timeout);
+        _swift_backtraceSettings.timeout = 0;
+      }
+    } else {
+      swift::warning(0,
+                     "swift runtime: bad backtracing timeout '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("unwind")) {
+    if (value.equals_insensitive("auto"))
+      _swift_backtraceSettings.algorithm = UnwindAlgorithm::Auto;
+    else if (value.equals_insensitive("fast"))
+      _swift_backtraceSettings.algorithm = UnwindAlgorithm::Fast;
+    else if (value.equals_insensitive("precise"))
+      _swift_backtraceSettings.algorithm = UnwindAlgorithm::Precise;
+    else {
+      swift::warning(0,
+                     "swift runtime: unknown unwind algorithm '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("sanitize")) {
+    _swift_backtraceSettings.sanitize
+      = parseBoolean(value) ? SanitizePaths::On : SanitizePaths::Off;
+  } else if (key.equals_insensitive("preset")) {
+    if (value.equals_insensitive("auto"))
+      _swift_backtraceSettings.preset = Preset::Auto;
+    else if (value.equals_insensitive("friendly"))
+      _swift_backtraceSettings.preset = Preset::Friendly;
+    else if (value.equals_insensitive("medium"))
+      _swift_backtraceSettings.preset = Preset::Medium;
+    else if (value.equals_insensitive("full"))
+      _swift_backtraceSettings.preset = Preset::Full;
+    else {
+      swift::warning(0,
+                     "swift runtime: unknown backtracing preset '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("threads")) {
+    if (value.equals_insensitive("all"))
+      _swift_backtraceSettings.threads = ThreadsToShow::All;
+    else if (value.equals_insensitive("crashed"))
+      _swift_backtraceSettings.threads = ThreadsToShow::Crashed;
+    else {
+      swift::warning(0,
+                     "swift runtime: unknown threads setting '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("registers")) {
+    if (value.equals_insensitive("none"))
+      _swift_backtraceSettings.registers = RegistersToShow::None;
+    else if (value.equals_insensitive("all"))
+      _swift_backtraceSettings.registers = RegistersToShow::All;
+    else if (value.equals_insensitive("crashed"))
+      _swift_backtraceSettings.registers = RegistersToShow::Crashed;
+    else {
+      swift::warning(0,
+                     "swift runtime: unknown registers setting '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("images")) {
+    if (value.equals_insensitive("none"))
+      _swift_backtraceSettings.images = ImagesToShow::None;
+    else if (value.equals_insensitive("all"))
+      _swift_backtraceSettings.images = ImagesToShow::All;
+    else if (value.equals_insensitive("mentioned"))
+      _swift_backtraceSettings.images = ImagesToShow::Mentioned;
+    else {
+      swift::warning(0,
+                     "swift runtime: unknown registers setting '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("limit")) {
+    int limit;
+    // Yes, getAsInteger() returns false for success.
+    if (value.equals_insensitive("none"))
+      _swift_backtraceSettings.limit = -1;
+    else if (!value.getAsInteger(0, limit) && limit > 0)
+      _swift_backtraceSettings.limit = limit;
+    else {
+      swift::warning(0,
+                     "swift runtime: bad backtrace limit '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("top")) {
+    int top;
+    // (If you think the next line is wrong, see above.)
+    if (!value.getAsInteger(0, top) && top >= 0)
+      _swift_backtraceSettings.top = top;
+    else {
+       swift::warning(0,
+                     "swift runtime: bad backtrace top count '%.*s'\n",
+                     static_cast<int>(value.size()), value.data());
+    }
+  } else if (key.equals_insensitive("swift-backtrace")) {
+    size_t len = value.size();
+    char *path = (char *)std::malloc(len + 1);
+    std::copy(value.begin(), value.end(), path);
+    path[len] = 0;
+
+    std::free(const_cast<char *>(_swift_backtraceSettings.swiftBacktracePath));
+    _swift_backtraceSettings.swiftBacktracePath = path;
+  } else {
+    swift::warning(0,
+                   "swift runtime: unknown backtracing setting '%.*s'\n",
+                   static_cast<int>(key.size()), key.data());
+  }
+}
+
+void
+_swift_parseBacktracingSettings(const char *settings)
+{
+  const char *ptr = settings;
+  const char *key = ptr;
+  const char *keyEnd;
+  const char *value;
+  const char *valueEnd;
+  enum {
+    ScanningKey,
+    ScanningValue
+  } state = ScanningKey;
+  int ch;
+
+  while ((ch = *ptr++)) {
+    switch (state) {
+    case ScanningKey:
+      if (ch == '=') {
+        keyEnd = ptr - 1;
+        value = ptr;
+        state = ScanningValue;
+        continue;
+      }
+      break;
+    case ScanningValue:
+      if (ch == ',') {
+        valueEnd = ptr - 1;
+
+        _swift_processBacktracingSetting(llvm::StringRef(key, keyEnd - key),
+                                         llvm::StringRef(value,
+                                                         valueEnd - value));
+
+        key = ptr;
+        state = ScanningKey;
+        continue;
+      }
+      break;
+    }
+  }
+
+  if (state == ScanningValue) {
+    valueEnd = ptr - 1;
+    _swift_processBacktracingSetting(llvm::StringRef(key, keyEnd - key),
+                                     llvm::StringRef(value,
+                                                     valueEnd - value));
+  }
+}
+
+#if SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
+// These are the only environment variables that are passed through to
+// the swift-backtrace process.  They're copied at program start, and then
+// write protected so they can't be manipulated by an attacker using a buffer
+// overrun.
+const char * const environmentVarsToPassThrough[] = {
+  "LD_LIBRARY_PATH",
+  "DYLD_LIBRARY_PATH",
+  "DYLD_FRAMEWORK_PATH",
+  "PATH",
+  "TERM",
+  "LANG",
+  "HOME"
+};
+
+#define BACKTRACE_MAX_ENV_VARS lengthof(environmentVarsToPassThrough)
+
+void
+_swift_backtraceSetupEnvironment()
+{
+  size_t remaining = sizeof(swiftBacktraceEnv);
+  char *penv = swiftBacktraceEnv;
+
+  std::memset(swiftBacktraceEnv, 0, sizeof(swiftBacktraceEnv));
+
+  // We definitely don't want this on in the swift-backtrace program
+  const char * const disable = "SWIFT_BACKTRACE=enable=no";
+  const size_t disableLen = std::strlen(disable) + 1;
+  std::memcpy(penv, disable, disableLen);
+  penv += disableLen;
+  remaining -= disableLen;
+
+  for (unsigned n = 0; n < BACKTRACE_MAX_ENV_VARS; ++n) {
+    const char *name = environmentVarsToPassThrough[n];
+    const char *value = getenv(name);
+    if (!value)
+      continue;
+
+    size_t nameLen = std::strlen(name);
+    size_t valueLen = std::strlen(value);
+    size_t totalLen = nameLen + 1 + valueLen + 1;
+
+    if (remaining > totalLen) {
+      std::memcpy(penv, name, nameLen);
+      penv += nameLen;
+      *penv++ = '=';
+      std::memcpy(penv, value, valueLen);
+      penv += valueLen;
+      *penv++ = 0;
+
+      remaining -= totalLen;
+    }
+  }
+
+  *penv = 0;
+}
+
+#endif // SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
+
+} // namespace
+
+namespace swift {
+namespace runtime {
+namespace backtrace {
+
+/// Test if a Swift symbol name represents a thunk function.
+///
+/// In backtraces, it is often desirable to omit thunk frames as they usually
+/// just clutter up the backtrace unnecessarily.
+///
+/// @param mangledName is the symbol name to be tested.
+///
+/// @returns `true` if `mangledName` represents a thunk function.
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift) bool
+_swift_isThunkFunction(const char *mangledName) {
+  swift::Demangle::Context ctx;
+
+  return ctx.isThunkSymbol(mangledName);
+}
+
+// N.B. THIS FUNCTION MUST BE SAFE TO USE FROM A CRASH HANDLER.  On Linux
+// and macOS, that means it must be async-signal-safe.  On Windows, there
+// isn't an equivalent notion but a similar restriction applies.
+SWIFT_RUNTIME_STDLIB_INTERNAL bool
+_swift_spawnBacktracer(const ArgChar * const *argv)
+{
+#if TARGET_OS_OSX
+  pid_t child;
+  const char *env[BACKTRACE_MAX_ENV_VARS + 1];
+
+  // Set-up the environment array
+  const char *ptr = swiftBacktraceEnv;
+  unsigned nEnv = 0;
+  while (*ptr && nEnv < lengthof(env) - 1) {
+    env[nEnv++] = ptr;
+    ptr += std::strlen(ptr) + 1;
+  };
+  env[nEnv] = 0;
+
+  // SUSv3 says argv and envp are "completely constant" and that the reason
+  // posix_spawn() et al use char * const * is for compatibility.
+  int ret = posix_spawn(&child, swiftBacktracePath,
+                        &backtraceFileActions, &backtraceSpawnAttrs,
+                        const_cast<char * const *>(argv),
+                        const_cast<char * const *>(env));
+  if (ret < 0)
+    return false;
+
+  int wstatus;
+
+  do {
+    ret = waitpid(child, &wstatus, 0);
+  } while (ret < 0 && errno == EINTR);
+
+  if (WIFEXITED(wstatus))
+    return WEXITSTATUS(wstatus) == 0;
+
+  return false;
+
+  // ###TODO: Linux
+  // ###TODO: Windows
+#else
+  return false;
+#endif
+}
+
+} // namespace backtrace
+} // namespace runtime
+} // namespace swift

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -289,7 +289,7 @@ BacktraceInitializer::BacktraceInitializer() {
   if (_swift_backtraceSettings.enabled == OnOffTty::On
       && !_swift_backtraceSettings.swiftBacktracePath) {
     _swift_backtraceSettings.swiftBacktracePath
-      = swift_getAuxiliaryExecutablePath("swift-backtrace");
+      = swift_copyAuxiliaryExecutablePath("swift-backtrace");
 
     if (!_swift_backtraceSettings.swiftBacktracePath) {
       swift::warning(0,

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -30,9 +30,11 @@ set(swift_runtime_sources
     AnyHashableSupport.cpp
     Array.cpp
     AutoDiffSupport.cpp
+    Backtrace.cpp
     Bincompat.cpp
     BytecodeLayouts.cpp
     Casting.cpp
+    CrashHandlerMacOS.cpp
     CrashReporter.cpp
     Demangle.cpp
     DynamicCast.cpp

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -1,0 +1,448 @@
+//===--- CrashHandlerMacOS.cpp - Swift crash handler for macOS ----------- ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The macOS crash handler implementation.
+//
+// We use signal handling rather than trying to use Mach exceptions here,
+// because the latter would entail running a separate Mach server thread, and
+// creates a much greater risk of interfering with the system wide Crash
+// Reporter, which is a no-no.
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __APPLE__
+
+#include <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+
+#include <mach/mach.h>
+#include <mach/task.h>
+#include <mach/thread_act.h>
+
+#include <sys/mman.h>
+#include <sys/ucontext.h>
+#include <sys/wait.h>
+
+#include <os/lock.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <spawn.h>
+#include <unistd.h>
+
+#include "swift/Runtime/Backtrace.h"
+
+#include <cstring>
+
+#ifndef lengthof
+#define lengthof(x)     (sizeof(x) / sizeof(x[0]))
+#endif
+
+using namespace swift::runtime::backtrace;
+
+namespace {
+
+void handle_fatal_signal(int signum, siginfo_t *pinfo, void *uctx);
+void suspend_other_threads();
+void resume_other_threads();
+bool run_backtracer(void);
+
+swift::CrashInfo crashInfo;
+
+os_unfair_lock crashLock = OS_UNFAIR_LOCK_INIT;
+
+const int signalsToHandle[] = {
+  SIGQUIT,
+  SIGABRT,
+  SIGBUS,
+  SIGFPE,
+  SIGILL,
+  SIGSEGV,
+  SIGTRAP
+};
+
+} // namespace
+
+namespace swift {
+namespace runtime {
+namespace backtrace {
+
+SWIFT_RUNTIME_STDLIB_INTERNAL int
+_swift_installCrashHandler()
+{
+  stack_t ss;
+
+  // Install an alternate signal handling stack
+  ss.ss_flags = 0;
+  ss.ss_size = SIGSTKSZ;
+  ss.ss_sp = mmap(0, ss.ss_size, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (ss.ss_sp == MAP_FAILED)
+    return errno;
+
+  if (sigaltstack(&ss, 0) < 0)
+    return errno;
+
+  // Now register signal handlers
+  struct sigaction sa;
+
+  sigfillset(&sa.sa_mask);
+  for (unsigned n = 0; n < lengthof(signalsToHandle); ++n) {
+    sigdelset(&sa.sa_mask, signalsToHandle[n]);
+  }
+
+  sa.sa_handler = NULL;
+
+  for (unsigned n = 0; n < lengthof(signalsToHandle); ++n) {
+    sa.sa_flags = SA_ONSTACK | SA_SIGINFO | SA_NODEFER;
+    sa.sa_sigaction = handle_fatal_signal;
+
+    if (sigaction(signalsToHandle[n], &sa, NULL) < 0)
+      return errno;
+  }
+
+  return 0;
+}
+
+} // namespace backtrace
+} // namespace runtime
+} // namespace swift
+
+namespace {
+
+void
+suspend_other_threads()
+{
+  os_unfair_lock_lock(&crashLock);
+
+  thread_t self = mach_thread_self();
+  thread_act_array_t threads;
+  mach_msg_type_number_t count = 0;
+
+  kern_return_t kr = task_threads(mach_task_self(), &threads, &count);
+
+  if (kr != KERN_SUCCESS)
+    return;
+
+  for (unsigned n = 0; n < count; ++n) {
+    if (threads[n] == self)
+      continue;
+
+    // Ignore the results of these two; if they fail there's nothing we can do
+    (void)thread_resume(threads[n]);
+    (void)mach_port_deallocate(mach_task_self(), threads[n]);
+  }
+
+  vm_deallocate(mach_task_self(),
+                (vm_address_t)threads,
+                count * sizeof(threads[0]));
+
+  os_unfair_lock_unlock(&crashLock);
+}
+
+void
+resume_other_threads()
+{
+  os_unfair_lock_lock(&crashLock);
+
+  thread_t self = mach_thread_self();
+  thread_act_array_t threads;
+  mach_msg_type_number_t count = 0;
+
+  kern_return_t kr = task_threads(mach_task_self(), &threads, &count);
+
+  if (kr != KERN_SUCCESS)
+    return;
+
+  for (unsigned n = 0; n < count; ++n) {
+    if (threads[n] == self)
+      continue;
+
+    // Ignore the results of these two; if they fail there's nothing we can do
+    (void)thread_resume(threads[n]);
+    (void)mach_port_deallocate(mach_task_self(), threads[n]);
+  }
+
+  vm_deallocate(mach_task_self(),
+                (vm_address_t)threads,
+                count * sizeof(threads[0]));
+
+  os_unfair_lock_unlock(&crashLock);
+}
+
+void
+handle_fatal_signal(int signum,
+                    siginfo_t *pinfo,
+                    void *uctx)
+{
+  int old_err = errno;
+
+  // Prevent this from exploding if more than one thread gets here at once
+  suspend_other_threads();
+
+  // Remove our signal handlers; crashes should kill us here
+  for (unsigned n = 0; n < lengthof(signalsToHandle); ++n)
+    signal(signalsToHandle[n], SIG_DFL);
+
+  // Get our thread identifier
+  thread_identifier_info_data_t ident_info;
+  mach_msg_type_number_t ident_size = THREAD_IDENTIFIER_INFO_COUNT;
+
+  int ret = thread_info(mach_thread_self(),
+                        THREAD_IDENTIFIER_INFO,
+                        (int *)&ident_info,
+                        &ident_size);
+  if (ret != KERN_SUCCESS)
+    return;
+
+  // Fill in crash info
+  crashInfo.crashing_thread = ident_info.thread_id;
+  crashInfo.signal = signum;
+  crashInfo.fault_address = (uint64_t)pinfo->si_addr;
+  crashInfo.mctx = (uint64_t)(((ucontext_t *)uctx)->uc_mcontext);
+
+  /* Start the backtracer; this will suspend the process, so there's no need
+     to try to suspend other threads from here. */
+  run_backtracer();
+
+  // Restart the other threads
+  resume_other_threads();
+
+  // Restore errno and exit (to crash)
+  errno = old_err;
+}
+
+char addr_buf[18];
+char timeout_buf[22];
+char limit_buf[22];
+char top_buf[22];
+const char *backtracer_argv[] = {
+  "swift-backtrace",            // 0
+  "--unwind",                   // 1
+  "precise",                    // 2
+  "--demangle",                 // 3
+  "true",                       // 4
+  "--interactive",              // 5
+  "true",                       // 6
+  "--color",                    // 7
+  "true",                       // 8
+  "--timeout",                  // 9
+  timeout_buf,                  // 10
+  "--preset",                   // 11
+  "friendly",                   // 12
+  "--crashinfo",                // 13
+  addr_buf,                     // 14
+  "--threads",                  // 15
+  "preset",                     // 16
+  "--registers",                // 17
+  "preset",                     // 18
+  "--images",                   // 19
+  "preset",                     // 20
+  "--limit",                    // 21
+  limit_buf,                    // 22
+  "--top",                      // 23
+  top_buf,                      // 24
+  "--sanitize",                 // 25
+  "preset",                     // 26
+  NULL
+};
+
+// We can't call sprintf() here because we're in a signal handler,
+// so we need to be async-signal-safe.
+void
+format_address(uintptr_t addr, char buffer[18])
+{
+  char *ptr = buffer + 18;
+  *--ptr = '\0';
+  while (ptr > buffer) {
+    char digit = '0' + (addr & 0xf);
+    if (digit > '9')
+      digit += 'a' - '0' - 10;
+    *--ptr = digit;
+    addr >>= 4;
+    if (!addr)
+      break;
+  }
+
+  // Left-justify in the buffer
+  if (ptr > buffer) {
+    char *pt2 = buffer;
+    while (*ptr)
+      *pt2++ = *ptr++;
+    *pt2++ = '\0';
+  }
+}
+void
+format_address(const void *ptr, char buffer[18])
+{
+  format_address(reinterpret_cast<uintptr_t>(ptr), buffer);
+}
+
+// See above; we can't use sprintf() here.
+void
+format_unsigned(unsigned u, char buffer[22])
+{
+  char *ptr = buffer + 22;
+  *--ptr = '\0';
+  while (ptr > buffer) {
+    char digit = '0' + (u % 10);
+    *--ptr = digit;
+    u /= 10;
+    if (!u)
+      break;
+  }
+
+  // Left-justify in the buffer
+  if (ptr > buffer) {
+    char *pt2 = buffer;
+    while (*ptr)
+      *pt2++ = *ptr++;
+    *pt2++ = '\0';
+  }
+}
+
+const char *
+trueOrFalse(bool b) {
+  return b ? "true" : "false";
+}
+
+const char *
+trueOrFalse(OnOffTty oot) {
+  return trueOrFalse(oot == OnOffTty::On);
+}
+
+bool
+run_backtracer()
+{
+  // Forward our task port to the backtracer; we use the same technique that
+  // libxpc uses to forward one of its ports on fork(), except that we aren't
+  // going to call fork() so libxpc's atfork handler won't run and we'll get
+  // to send the task port to the child.
+  //
+  // I would very much like to send a task *read* port, but for some reason
+  // that doesn't work here.  As a result, what we do instead is send the
+  // control port but have the backtracer use it to get the read port and
+  // immediately drop the control port.
+  //
+  // That *should* be safe enough in practice; if someone could replace the
+  // backtracer, then they can also replace libswiftCore, and since we do
+  // this early on in backtracer start-up, the control port won't be valid
+  // by the time anyone gets to try anything nefarious.
+  mach_port_t ports[] = {
+    mach_task_self(),
+  };
+
+  mach_ports_register(mach_task_self(), ports, 1);
+
+  // Set-up the backtracer's command line arguments
+  switch (_swift_backtraceSettings.algorithm) {
+  case UnwindAlgorithm::Fast:
+    backtracer_argv[2] = "fast";
+    break;
+  default:
+    backtracer_argv[2] = "precise";
+    break;
+  }
+
+  // (The TTY option has already been handled at this point, so these are
+  //  all either "On" or "Off".)
+  backtracer_argv[4] = trueOrFalse(_swift_backtraceSettings.demangle);
+  backtracer_argv[6] = trueOrFalse(_swift_backtraceSettings.interactive);
+  backtracer_argv[8] = trueOrFalse(_swift_backtraceSettings.color);
+
+  switch (_swift_backtraceSettings.threads) {
+  case ThreadsToShow::Preset:
+    backtracer_argv[16] = "preset";
+    break;
+  case ThreadsToShow::All:
+    backtracer_argv[16] = "all";
+    break;
+  case ThreadsToShow::Crashed:
+    backtracer_argv[16] = "crashed";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.registers) {
+  case RegistersToShow::Preset:
+    backtracer_argv[18] = "preset";
+    break;
+  case RegistersToShow::None:
+    backtracer_argv[18] = "none";
+    break;
+  case RegistersToShow::All:
+    backtracer_argv[18] = "all";
+    break;
+  case RegistersToShow::Crashed:
+    backtracer_argv[18] = "crashed";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.images) {
+  case ImagesToShow::Preset:
+    backtracer_argv[20] = "preset";
+    break;
+  case ImagesToShow::None:
+    backtracer_argv[20] = "none";
+    break;
+  case ImagesToShow::All:
+    backtracer_argv[20] = "all";
+    break;
+  case ImagesToShow::Mentioned:
+    backtracer_argv[20] = "mentioned";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.preset) {
+  case Preset::Friendly:
+    backtracer_argv[12] = "friendly";
+    break;
+  case Preset::Medium:
+    backtracer_argv[12] = "medium";
+    break;
+  default:
+    backtracer_argv[12] = "full";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.sanitize) {
+  case SanitizePaths::Preset:
+    backtracer_argv[26] = "preset";
+    break;
+  case SanitizePaths::Off:
+    backtracer_argv[26] = "false";
+    break;
+  case SanitizePaths::On:
+    backtracer_argv[26] = "true";
+    break;
+  }
+
+  format_unsigned(_swift_backtraceSettings.timeout, timeout_buf);
+
+  if (_swift_backtraceSettings.limit < 0)
+    std::strcpy(limit_buf, "none");
+  else
+    format_unsigned(_swift_backtraceSettings.limit, limit_buf);
+
+  format_unsigned(_swift_backtraceSettings.top, top_buf);
+  format_address(&crashInfo, addr_buf);
+
+  // Actually execute it
+  return _swift_spawnBacktracer(backtracer_argv);
+}
+
+} // namespace
+
+#endif // TARGET_OS_OSX
+
+#endif // __APPLE__
+

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -86,4 +86,9 @@ VARIABLE(SWIFT_ROOT, string, "",
          "This is used to locate auxiliary files relative to the runtime "
          "itself.")
 
+VARIABLE(SWIFT_BACKTRACE, string, "",
+         "A comma-separated list of key=value pairs that controls the "
+         "crash catching and backtracing support in the runtime. "
+         "See docs/Backtracing.rst in the Swift repository for details.")
+
 #undef VARIABLE


### PR DESCRIPTION
When a Swift program crashes, we should catch the crash and execute the external backtracer.

rdar://105391747
