### PR TITLE
[Backtracing] Add _Backtracing library to the build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,22 @@ else()
   set(CMAKE_JOB_POOL_LINK local_jobs)
 endif()
 
-ENABLE_LANGUAGE(C)
+enable_language(C)
+enable_language(CXX)
+
+# On Windows, use MASM or MARMASM
+set(SWIFT_ASM_DIALECT ASM)
+set(SWIFT_ASM_EXT S)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
+    set(SWIFT_ASM_DIALECT ASM_MARMASM)
+  else()
+    set(SWIFT_ASM_DIALECT ASM_MASM)
+  endif()
+  set(SWIFT_ASM_EXT asm)
+endif()
+
+enable_language(${SWIFT_ASM_DIALECT})
 
 # Use C++14.
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
@@ -609,7 +624,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 if(SWIFT_BUILT_STANDALONE)
-  project(Swift C CXX ASM)
+  project(Swift C CXX ${SWIFT_ASM_DIALECT})
 endif()
 
 if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL MSVC)
@@ -679,6 +694,7 @@ execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} ${version_flag}
 message(STATUS "CMake Make Program (${CMAKE_MAKE_PROGRAM}) Version: ${_CMAKE_MAKE_PROGRAM_VERSION}")
 message(STATUS "C Compiler (${CMAKE_C_COMPILER}) Version: ${CMAKE_C_COMPILER_VERSION}")
 message(STATUS "C++ Compiler (${CMAKE_CXX_COMPILER}) Version: ${CMAKE_CXX_COMPILER_VERSION}")
+message(STATUS "Assembler (${CMAKE_${SWIFT_ASM_DIALECT}_COMPILER}) Version: ${CMAKE_${SWIFT_ASM_DIALECT}_COMPILER_VERSION}")
 if (CMAKE_Swift_COMPILER)
   message(STATUS "Swift Compiler (${CMAKE_Swift_COMPILER}) Version: ${CMAKE_Swift_COMPILER_VERSION}")
 else()

--- a/include/swift/Runtime/Backtrace.h
+++ b/include/swift/Runtime/Backtrace.h
@@ -24,6 +24,16 @@
 
 #include <inttypes.h>
 
+#ifdef _WIN32
+// For DWORD
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+// For wchar_t
+#include <cwchar>
+#endif
+
 #ifdef __cplusplus
 namespace swift {
 namespace runtime {

--- a/stdlib/public/Backtracing/Backtrace.swift
+++ b/stdlib/public/Backtracing/Backtrace.swift
@@ -1,0 +1,496 @@
+//===--- Backtrace.swift --------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines the `Backtrace` struct that represents a captured backtrace.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+
+@_implementationOnly import Darwin.Mach
+@_implementationOnly import _SwiftBacktracingShims
+
+#endif
+
+/// Holds a backtrace.
+public struct Backtrace: CustomStringConvertible, Sendable {
+  /// The type of an address.
+  ///
+  /// This will be `UInt32` or `UInt64` on current platforms.
+  #if arch(x86_64) || arch(arm64)
+  public typealias Address = UInt64
+  #elseif arch(i386) || arch(arm)
+  public typealias Address = UInt32
+  #else
+  #error("You need to fill this in for your architecture.")
+  #endif
+
+  /// The unwind algorithm to use.
+  public enum UnwindAlgorithm {
+    /// Choose the most appropriate for the platform.
+    case auto
+
+    /// Use the fastest viable method.
+    ///
+    /// Typically this means walking the frame pointers.
+    case fast
+
+    /// Use the most precise available method.
+    ///
+    /// On Darwin and on ELF platforms, this will use EH unwind
+    /// information.  On Windows, it will use Win32 API functions.
+    case precise
+  }
+
+  /// Represents an individual frame in a backtrace.
+  public enum Frame: CustomStringConvertible, Sendable {
+    /// An accurate program counter.
+    ///
+    /// This might come from a signal handler, or an exception or some
+    /// other situation in which we have captured the actual program counter.
+    case programCounter(Address)
+
+    /// A return address.
+    ///
+    /// Corresponds to a normal function call.
+    case returnAddress(Address)
+
+    /// An async resume point.
+    ///
+    /// Corresponds to an `await` in an async task.
+    case asyncResumePoint(Address)
+
+    /// Indicates a discontinuity in the backtrace.
+    ///
+    /// This occurs when you set a limit and a minimum number of frames at
+    /// the top.  For example, if you set a limit of 10 frames and a minimum
+    /// of 4 top frames, but the backtrace generated 100 frames, you will see
+    ///
+    ///    0: frame 100 <----- bottom of call stack
+    ///    1: frame 99
+    ///    2: frame 98
+    ///    3: frame 97
+    ///    4: frame 96
+    ///    5: ...       <----- omittedFrames(92)
+    ///    6: frame 3
+    ///    7: frame 2
+    ///    8: frame 1
+    ///    9: frame 0   <----- top of call stack
+    ///
+    /// Note that the limit *includes* the discontinuity.
+    ///
+    /// This is good for handling cases involving deep recursion.
+    case omittedFrames(Int)
+
+    /// Indicates a discontinuity of unknown length.
+    case truncated
+
+    /// The program counter, without any adjustment.
+    public var originalProgramCounter: Address {
+      switch self {
+        case let .returnAddress(addr):
+          return addr
+        case let .programCounter(addr):
+          return addr
+        case let .asyncResumePoint(addr):
+          return addr
+        case .omittedFrames(_), .truncated:
+          return 0
+      }
+    }
+
+    /// The adjusted program counter to use for symbolication.
+    public var adjustedProgramCounter: Address {
+      switch self {
+        case let .returnAddress(addr):
+          return addr - 1
+        case let .programCounter(addr):
+          return addr
+        case let .asyncResumePoint(addr):
+          return addr
+        case .omittedFrames(_), .truncated:
+          return 0
+      }
+    }
+
+    /// A textual description of this frame.
+    public var description: String {
+      switch self {
+        case let .programCounter(addr):
+          return "\(hex(addr))"
+        case let .returnAddress(addr):
+          return "\(hex(addr)) [ra]"
+        case let .asyncResumePoint(addr):
+          return "\(hex(addr)) [async]"
+        case .omittedFrames(_), .truncated:
+          return "..."
+      }
+    }
+  }
+
+  /// Represents an image loaded in the process's address space
+  public struct Image: CustomStringConvertible, Sendable {
+    /// The name of the image (e.g. libswiftCore.dylib).
+    public var name: String
+
+    /// The full path to the image (e.g. /usr/lib/swift/libswiftCore.dylib).
+    public var path: String
+
+    /// The build ID of the image, as a byte array (note that the exact number
+    /// of bytes may vary, and that some images may not have a build ID).
+    public var buildID: [UInt8]?
+
+    /// The base address of the image.
+    public var baseAddress: Backtrace.Address
+
+    /// The end of the text segment in this image.
+    public var endOfText: Backtrace.Address
+
+    /// Provide a textual description of an Image.
+    public var description: String {
+      if let buildID = self.buildID {
+        return "\(hex(baseAddress))-\(hex(endOfText)) \(hex(buildID)) \(name) \(path)"
+      } else {
+        return "\(hex(baseAddress))-\(hex(endOfText)) <no build ID> \(name) \(path)"
+      }
+    }
+  }
+
+  /// A list of captured frame information.
+  public var frames: [Frame]
+
+  /// A list of captured images.
+  ///
+  /// Some backtracing algorithms may require this information, in which case
+  /// it will be filled in by the `capture()` method.  Other algorithms may
+  /// not, in which case it will be empty and you can capture an image list
+  /// separately yourself using `captureImages()`.
+  public var images: [Image]?
+
+  /// Holds information about the shared cache.
+  public struct SharedCacheInfo: Sendable {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    /// The UUID from the shared cache.
+    public var uuid: [UInt8]
+
+    /// The base address of the shared cache.
+    public var baseAddress: Backtrace.Address
+
+    /// Says whether there is in fact a shared cache.
+    public var noCache: Bool
+    #endif
+  }
+
+  /// Information about the shared cache.
+  ///
+  /// Holds information about the shared cache.  On Darwin only, this is
+  /// required for symbolication.  On non-Darwin platforms it will always
+  /// be `nil`.
+  public var sharedCacheInfo: SharedCacheInfo?
+
+  /// Capture a backtrace from the current program location.
+  ///
+  /// The `capture()` method itself will not be included in the backtrace;
+  /// i.e. the first frame will be the one in which `capture()` was called,
+  /// and its programCounter value will be the return address for the
+  /// `capture()` method call.
+  ///
+  /// @param algorithm     Specifies which unwind mechanism to use.  If this
+  ///                      is set to `.auto`, we will use the platform default.
+  /// @param limit         The backtrace will include at most this number of
+  ///                      frames; you can set this to `nil` to remove the
+  ///                      limit completely if required.
+  /// @param offset        Says how many frames to skip; this makes it easy to
+  ///                      wrap this API without having to inline things and
+  ///                      without including unnecessary frames in the backtrace.
+  /// @param top           Sets the minimum number of frames to capture at the
+  ///                      top of the stack.
+  ///
+  /// @returns A new `Backtrace` struct.
+  @inline(never)
+  public static func capture(algorithm: UnwindAlgorithm = .auto,
+                             limit: Int? = 64,
+                             offset: Int = 0,
+                             top: Int = 16) throws -> Backtrace {
+    // N.B. We use offset+1 here to skip this frame, rather than inlining
+    //      this code into the client.
+    return try HostContext.withCurrentContext { ctx in
+      try capture(from: ctx,
+                  using: UnsafeLocalMemoryReader(),
+                  algorithm: algorithm,
+                  limit: limit,
+                  offset: offset + 1,
+                  top: top)
+    }
+  }
+
+  @_spi(Internal)
+  public static func capture(from context: some Context,
+                             using memoryReader: some MemoryReader,
+                             algorithm: UnwindAlgorithm = .auto,
+                             limit: Int? = 64,
+                             offset: Int = 0,
+                             top: Int = 16) throws -> Backtrace {
+    switch algorithm {
+      // All of them, for now, use the frame pointer unwinder.  In the long
+      // run, we should be using DWARF EH frame data for .precise.
+      case .auto, .fast, .precise:
+        let unwinder =
+          FramePointerUnwinder(context: context, memoryReader: memoryReader)
+          .dropFirst(offset)
+
+        if let limit = limit {
+          if limit == 0 {
+            return Backtrace(frames: [.truncated])
+          }
+
+          let realTop = top < limit ? top : limit - 1
+          var iterator = unwinder.makeIterator()
+          var frames: [Frame] = []
+
+          // Capture frames normally until we hit limit
+          while let frame = iterator.next() {
+            if frames.count < limit {
+              frames.append(frame)
+              if frames.count == limit {
+                break
+              }
+            }
+          }
+
+          if realTop == 0 {
+            if let _ = iterator.next() {
+              // More frames than we were asked for; replace the last
+              // one with a discontinuity
+              frames[limit - 1] = .truncated
+            }
+
+            return Backtrace(frames: frames)
+          } else {
+
+            // If we still have frames at this point, start tracking the
+            // last `realTop` frames in a circular buffer.
+            if let frame = iterator.next() {
+              let topSection = limit - realTop
+              var topFrames: [Frame] = []
+              var topNdx = 0
+              var omittedFrames = 0
+
+              topFrames.reserveCapacity(realTop)
+              topFrames.insert(contentsOf: frames.suffix(realTop - 1), at: 0)
+              topFrames.append(frame)
+
+              while let frame = iterator.next() {
+                topFrames[topNdx] = frame
+                topNdx += 1
+                omittedFrames += 1
+                if topNdx >= realTop {
+                  topNdx = 0
+                }
+              }
+
+              // Fix the backtrace to include a discontinuity followed by
+              // the contents of the circular buffer.
+              let firstPart = realTop - topNdx
+              let secondPart = topNdx
+              frames[topSection - 1] = .omittedFrames(omittedFrames)
+
+              frames.replaceSubrange(topSection..<(topSection+firstPart),
+                                     with: topFrames.suffix(firstPart))
+              frames.replaceSubrange((topSection+firstPart)..<limit,
+                                     with: topFrames.prefix(secondPart))
+            }
+
+            return Backtrace(frames: frames)
+          }
+        } else {
+          return Backtrace(frames: Array(unwinder))
+        }
+    }
+  }
+
+  /// Capture a list of the images currently mapped into the calling
+  /// process.
+  ///
+  /// @returns A list of `Image`s.
+  public static func captureImages() -> [Image] {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    return captureImages(for: mach_task_self_)
+    #else
+    return []
+    #endif
+  }
+
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  private static func withDyldProcessInfo<T>(for task: task_t,
+                                             fn: (OpaquePointer?) throws -> T)
+    rethrows -> T {
+    var kret: kern_return_t = KERN_SUCCESS
+    let dyldInfo = _dyld_process_info_create(task, 0, &kret)
+
+    if kret != KERN_SUCCESS {
+      fatalError("error: cannot create dyld process info")
+    }
+
+    defer {
+      _dyld_process_info_release(dyldInfo)
+    }
+
+    return try fn(dyldInfo)
+  }
+  #endif
+
+  @_spi(Internal)
+  public static func captureImages(for process: Any) -> [Image] {
+    var images: [Image] = []
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    let task = process as! task_t
+
+    withDyldProcessInfo(for: task){ dyldInfo in
+      _dyld_process_info_for_each_image(dyldInfo) {
+        (machHeaderAddress, uuid, path) in
+
+        if let path = path, let uuid = uuid {
+          let pathString = String(cString: path)
+          let theUUID = Array(UnsafeBufferPointer(start: uuid,
+                                                count: MemoryLayout<uuid_t>.size))
+          let name: String
+          if let slashIndex = pathString.lastIndex(of: "/") {
+            name = String(pathString.suffix(from:
+                                              pathString.index(after:slashIndex)))
+          } else {
+            name = pathString
+          }
+
+          // Find the end of the __TEXT segment
+          var endOfText = machHeaderAddress + 4096
+
+          _dyld_process_info_for_each_segment(dyldInfo, machHeaderAddress){
+            address, size, name in
+
+            if let name = String(validatingUTF8: name!), name == "__TEXT" {
+              endOfText = address + size
+            }
+          }
+
+          images.append(Image(name: name,
+                              path: pathString,
+                              buildID: theUUID,
+                              baseAddress: machHeaderAddress,
+                              endOfText: endOfText))
+        }
+      }
+    }
+    #endif // os(macOS) || os(iOS) || os(watchOS)
+
+    return images.sorted(by: { $0.baseAddress < $1.baseAddress })
+  }
+
+  /// Capture shared cache information.
+  ///
+  /// @returns A `SharedCacheInfo`.
+  public static func captureSharedCacheInfo() -> SharedCacheInfo {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    return captureSharedCacheInfo(for: mach_task_self_)
+    #else
+    return SharedCacheInfo()
+    #endif
+  }
+
+  @_spi(Internal)
+  public static func captureSharedCacheInfo(for t: Any) -> SharedCacheInfo {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    let task = t as! task_t
+    return withDyldProcessInfo(for: task){ dyldInfo in
+      var cacheInfo = dyld_process_cache_info()
+      _dyld_process_info_get_cache(dyldInfo, &cacheInfo)
+      let theUUID = withUnsafePointer(to: cacheInfo.cacheUUID){
+        $0.withMemoryRebound(to: UInt8.self,
+                             capacity: MemoryLayout<uuid_t>.size) {
+          Array(UnsafeBufferPointer(start: $0,
+                                    count: MemoryLayout<uuid_t>.size))
+        }
+      }
+      return SharedCacheInfo(uuid: theUUID,
+                             baseAddress: cacheInfo.cacheBaseAddress,
+                             noCache: cacheInfo.noCache)
+    }
+    #else // !os(Darwin)
+    return SharedCacheInfo()
+    #endif
+  }
+
+  /// Return a symbolicated version of the backtrace.
+  ///
+  /// @param images Specifies the set of images to use for symbolication.
+  ///               If `nil`, the function will look to see if the `Backtrace`
+  ///               has already captured images.  If it has, those will be
+  ///               used; otherwise we will capture images at this point.
+  ///
+  /// @param sharedCacheInfo  Provides information about the location and
+  ///                         identity of the shared cache, if applicable.
+  ///
+  /// @param showInlineFrames If `true` and we know how on the platform we're
+  ///                         running on, add virtual frames to show inline
+  ///                         function calls.
+  ///
+  /// @returns A new `SymbolicatedBacktrace`.
+  public func symbolicated(with images: [Image]? = nil,
+                           sharedCacheInfo: SharedCacheInfo? = nil,
+                           showInlineFrames: Bool = true)
+    -> SymbolicatedBacktrace? {
+    return SymbolicatedBacktrace.symbolicate(backtrace: self,
+                                             images: images,
+                                             sharedCacheInfo: sharedCacheInfo,
+                                             showInlineFrames: showInlineFrames)
+  }
+
+  /// Provide a textual version of the backtrace.
+  public var description: String {
+    var lines: [String] = []
+
+    var n = 0
+    for frame in frames {
+      lines.append("\(n)\t\(frame)")
+      switch frame {
+        case let .omittedFrames(count):
+          n += count
+        default:
+          n += 1
+      }
+    }
+
+    if let images = images {
+      lines.append("")
+      lines.append("Images:")
+      lines.append("")
+      for (n, image) in images.enumerated() {
+        lines.append("\(n)\t\(image)")
+      }
+    }
+
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    if let sharedCacheInfo = sharedCacheInfo {
+      lines.append("")
+      lines.append("Shared Cache:")
+      lines.append("")
+      lines.append("  UUID: \(hex(sharedCacheInfo.uuid))")
+      lines.append("  Base: \(hex(sharedCacheInfo.baseAddress))")
+    }
+    #endif
+
+    return lines.joined(separator: "\n")
+  }
+}

--- a/stdlib/public/Backtracing/BacktraceFormatter.swift
+++ b/stdlib/public/Backtracing/BacktraceFormatter.swift
@@ -1,0 +1,983 @@
+//===--- BacktraceFormatter.swift -----------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Provides functionality to format backtraces, with various additional
+//  options.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@_implementationOnly import Darwin
+#elseif os(Windows)
+@_implementationOnly import MSVCRT
+#elseif os(Linux)
+@_implementationOnly import Glibc
+#endif
+
+@_implementationOnly import _SwiftBacktracingShims
+
+/// A backtrace formatting theme.
+@_spi(Formatting)
+public protocol BacktraceFormattingTheme {
+  func frameIndex(_ s: String) -> String
+  func programCounter(_ s: String) -> String
+  func frameAttribute(_ s: String) -> String
+  func symbol(_ s: String) -> String
+  func offset(_ s: String) -> String
+  func sourceLocation(_ s: String) -> String
+  func lineNumber(_ s: String) -> String
+  func code(_ s: String) -> String
+  func crashedLine(_ s: String) -> String
+  func crashLocation(_ s: String) -> String
+  func imageName(_ s: String) -> String
+  func imageAddressRange(_ s: String) -> String
+  func imageBuildID(_ s: String) -> String
+  func imagePath(_ s: String) -> String
+}
+
+extension BacktraceFormattingTheme {
+  public func frameIndex(_ s: String) -> String { return s }
+  public func programCounter(_ s: String) -> String { return s }
+  public func frameAttribute(_ s: String) -> String { return "[\(s)]" }
+  public func symbol(_ s: String) -> String { return s }
+  public func offset(_ s: String) -> String { return s }
+  public func sourceLocation(_ s: String) -> String { return s }
+  public func lineNumber(_ s: String) -> String { return s }
+  public func code(_ s: String) -> String { return s }
+  public func crashedLine(_ s: String) -> String { return s }
+  public func crashLocation(_ s: String) -> String { return s }
+  public func imageName(_ s: String) -> String { return s }
+  public func imageAddressRange(_ s: String) -> String { return s }
+  public func imageBuildID(_ s: String) -> String { return s }
+  public func imagePath(_ s: String) -> String { return s}
+}
+
+/// Options for backtrace formatting.
+///
+/// This is used by chaining modifiers, e.g. .theme(.color).showSourceCode().
+@_spi(Formatting)
+public struct BacktraceFormattingOptions {
+  var _theme: BacktraceFormattingTheme = BacktraceFormatter.Themes.plain
+  var _showSourceCode: Bool = false
+  var _sourceContextLines: Int = 2
+  var _showAddresses: Bool = true
+  var _showImages: ImagesToShow = .mentioned
+  var _showImageNames: Bool = true
+  var _showFrameAttributes: Bool = true
+  var _skipRuntimeFailures: Bool = false
+  var _skipThunkFunctions: Bool = true
+  var _skipSystemFrames: Bool = true
+  var _sanitizePaths: Bool = true
+  var _demangle: Bool = true
+  var _width: Int = 80
+
+  public var selectedTheme: BacktraceFormattingTheme { return _theme }
+  public var shouldShowSourceCode: Bool { return _showSourceCode }
+  public var sourceContextLines: Int { return _sourceContextLines }
+  public var shouldShowAddresses: Bool { return _showAddresses }
+  public var imagesToShow: ImagesToShow { return _showImages }
+  public var shouldShowImageNames: Bool { return _showImageNames }
+  public var shouldShowFrameAttributes: Bool { return _showFrameAttributes }
+  public var shouldSkipRuntimeFailures: Bool { return _skipRuntimeFailures }
+  public var shouldSkipThunkFunctions: Bool { return _skipThunkFunctions }
+  public var shouldSkipSystemFrames: Bool { return _skipSystemFrames }
+  public var shouldSanitizePaths: Bool { return _sanitizePaths }
+  public var shouldDemangle: Bool { return _demangle }
+  public var formattingWidth: Int { return _width }
+
+  public init() {}
+
+  /// Theme to use for formatting.
+  ///
+  /// @param theme  A `BacktraceFormattingTheme` structure.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func theme(_ theme: BacktraceFormattingTheme) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().theme(theme)
+  }
+  public func theme(_ theme: BacktraceFormattingTheme) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._theme = theme
+    return newOptions
+  }
+
+  /// Enable or disable the display of source code in the backtrace.
+  ///
+  /// @param enabled       Whether or not to enable source code.
+  ///
+  /// @param contextLines  The number of lines of context either side of the
+  ///                      line associated with the backtrace frame.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func showSourceCode(_ enabled: Bool = true, contextLines: Int = 2) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().showSourceCode(enabled,
+                                                       contextLines: contextLines)
+  }
+  public func showSourceCode(_ enabled: Bool = true, contextLines: Int = 2) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._showSourceCode = enabled
+    newOptions._sourceContextLines = contextLines
+    return newOptions
+  }
+
+  /// Enable or disable the display of raw addresses.
+  ///
+  /// @param enabled  If false, we will only display a raw address in the
+  ///                 backtrace if we haven't been able to symbolicate.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func showAddresses(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().showAddresses(enabled)
+  }
+  public func showAddresses(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._showAddresses = enabled
+    return newOptions
+  }
+
+  /// Enable or disable the display of the image list.
+  ///
+  /// @param enabled  Says whether or not to output the image list.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public enum ImagesToShow {
+    case none
+    case mentioned
+    case all
+  }
+  public static func showImages(_ toShow: ImagesToShow = .all) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().showImages(toShow)
+  }
+  public func showImages(_ toShow: ImagesToShow = .all) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._showImages = toShow
+    return newOptions
+  }
+
+  /// Enable or disable the display of image names in the frame list.
+  ///
+  /// @param enabled  If true, we will display the name of the image for
+  ///                 each frame.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func showImageNames(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().showImageNames(enabled)
+  }
+  public func showImageNames(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._showImageNames = enabled
+    return newOptions
+  }
+
+  /// Enable or disable the display of frame attributes in the frame list.
+  ///
+  /// @param enabled  If true, we will display the frame attributes.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func showFrameAttributes(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().showFrameAttributes(enabled)
+  }
+  public func showFrameAttributes(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._showFrameAttributes = enabled
+    return newOptions
+  }
+
+  /// Set whether or not to show Swift runtime failure frames.
+  ///
+  /// @param enabled  If true, we will skip Swift runtime failure frames.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func skipRuntimeFailures(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().skipRuntimeFailures(enabled)
+  }
+  public func skipRuntimeFailures(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._skipRuntimeFailures = enabled
+    return newOptions
+  }
+
+  /// Set whether or not to show Swift thunk function frames.
+  ///
+  /// @param enabled  If true, we will skip Swift thunk function frames.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func skipThunkFunctions(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().skipThunkFunctions(enabled)
+  }
+  public func skipThunkFunctions(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._skipThunkFunctions = enabled
+    return newOptions
+  }
+
+  /// Set whether or not to show system frames.
+  ///
+  /// For instance, on macOS, this will cause us to skip the "start" frame
+  /// at the very top of the stack.
+  ///
+  /// @param enabled  If true, we will skip system frames.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func skipSystemFrames(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().skipSystemFrames(enabled)
+  }
+  public func skipSystemFrames(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._skipSystemFrames = enabled
+    return newOptions
+  }
+
+  /// Enable or disable path sanitization.
+  ///
+  /// This is intended to avoid leaking PII into crash logs.
+  ///
+  /// @param enabled  If true, paths will be sanitized.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func sanitizePaths(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().sanitizePaths(enabled)
+  }
+  public func sanitizePaths(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._sanitizePaths = enabled
+    return newOptions
+  }
+
+  /// Set whether we show mangled or demangled names.
+  ///
+  /// @param enabled  If true, we show demangled names if we have them.
+  ///
+  /// @returns A new `BacktraceFormattingOptions` structure.
+  public static func demangle(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().demangle(enabled)
+  }
+  public func demangle(_ enabled: Bool = true) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._demangle = enabled
+    return newOptions
+  }
+
+  /// Set the output width.
+  ///
+  /// @param width  The output width in characters.  This is only used to
+  ///               highlight information, and defaults to 80.
+  ///
+  /// returns A new `BacktraceFormattingOptions` structure.
+  public static func width(_ width: Int) -> BacktraceFormattingOptions {
+    return BacktraceFormattingOptions().width(width)
+  }
+  public func width(_ width: Int) -> BacktraceFormattingOptions {
+    var newOptions = self
+    newOptions._width = width
+    return newOptions
+  }
+}
+
+/// Return the width of a given Unicode.Scalar.
+///
+/// It would be nice to have the Unicode width data, which would let us do
+/// a better job of this.
+private func measure(_ ch: Unicode.Scalar) -> Int {
+  if ch.isASCII {
+    return 1
+  }
+
+  if #available(macOS 10.12.2, *) {
+    if ch.properties.isEmoji {
+      return 2
+    }
+  } else if ch.value >= 0x1f100 && ch.value <= 0x1fb00 {
+    return 2
+  }
+
+  if ch.properties.isIdeographic
+       && !(ch.value >= 0xff61 && ch.value <= 0xffdc)
+       && !(ch.value >= 0xffe8 && ch.value <= 0xffee) {
+    return 2
+  }
+
+  if ch.properties.canonicalCombiningClass.rawValue != 0 {
+    return 0
+  }
+
+  switch ch.properties.generalCategory {
+    case .control, .nonspacingMark:
+      return 0
+    default:
+      return 1
+  }
+}
+
+/// Compute the width of the given string, ignoring CSI formatting codes.
+private enum MeasureState {
+  // Normal state
+  case normal
+
+  // Start of an escape
+  case escape
+
+  // In a CSI escape
+  case csi
+}
+
+private func measure<S: StringProtocol>(_ s: S) -> Int {
+  var totalWidth = 0
+  var state: MeasureState = .normal
+
+  for ch in s.unicodeScalars {
+    switch state {
+      case .normal:
+        if ch.value == 27 {
+          // This is an escape sequence
+          state = .escape
+        } else {
+          totalWidth += measure(ch)
+        }
+      case .escape:
+        if ch.value == 0x5b {
+          state = .csi
+        } else {
+          state = .normal
+        }
+      case .csi:
+        if ch.value >= 0x40 && ch.value <= 0x7e {
+          state = .normal
+        }
+    }
+  }
+  return totalWidth
+}
+
+/// Pad the given string to the given width using spaces.
+private func pad(_ s: String, to width: Int,
+                 aligned alignment: BacktraceFormatter.Alignment = .left)
+  -> String {
+
+  let currentWidth = measure(s)
+  let padding = max(width - currentWidth, 0)
+
+  switch alignment {
+    case .left:
+      let spaces = String(repeating: " ", count: padding)
+
+      return s + spaces
+    case .right:
+      let spaces = String(repeating: " ", count: padding)
+
+      return spaces + s
+    case .center:
+      let left = padding / 2
+      let right = padding - left
+      let leftSpaces = String(repeating: " ", count: left)
+      let rightSpaces = String(repeating: " ", count: right)
+
+      return "\(leftSpaces)\(s)\(rightSpaces)"
+  }
+}
+
+/// Untabify the given string, assuming tabs of the specified size.
+///
+/// @param s         The string to untabify.
+/// @param tabWidth  The tab width to assume (default 8).
+///
+/// @returns A string with all the tabs replaced with appropriate numbers
+///          of spaces.
+private func untabify(_ s: String, tabWidth: Int = 8) -> String {
+  var result: String = ""
+  var first = true
+  for chunk in s.split(separator: "\t", omittingEmptySubsequences: false) {
+    if first {
+      first = false
+    } else {
+      let toTabStop = tabWidth - measure(result) % tabWidth
+      result += String(repeating: " ", count: toTabStop)
+    }
+    result += chunk
+  }
+  return result
+}
+
+/// Sanitize a path to remove usernames, volume names and so on.
+///
+/// The point of this function is to try to remove anything that might
+/// contain PII before it ends up in a log file somewhere.
+///
+/// @param path  The path to sanitize.
+///
+/// @returns A string containing the sanitized path.
+private func sanitizePath(_ path: String) -> String {
+  #if os(macOS)
+  return CRCopySanitizedPath(path,
+                             kCRSanitizePathGlobAllTypes
+                               | kCRSanitizePathKeepFile)
+  #else
+  // For now, on non-macOS systems, do nothing
+  return path
+  #endif
+}
+
+/// Trim whitespace from the right hand end of a string.
+///
+/// @param s  The string to trim.
+///
+/// @returns A string with the whitespace trimmed.
+private func rtrim<S: StringProtocol>(_ s: S) -> S.SubSequence {
+  if let lastNonWhitespace = s.lastIndex(where: { !$0.isWhitespace }) {
+    return s.prefix(through: lastNonWhitespace)
+  }
+  return s.dropLast(0)
+}
+
+/// Responsible for formatting backtraces.
+@_spi(Formatting)
+public struct BacktraceFormatter {
+
+  /// The formatting options to apply when formatting data.
+  public var options: BacktraceFormattingOptions
+
+  public struct Themes {
+    /// A plain formatting theme.
+    public struct PlainTheme: BacktraceFormattingTheme {
+    }
+
+    public static let plain = PlainTheme()
+  }
+
+  public init(_ options: BacktraceFormattingOptions) {
+    self.options = options
+  }
+
+  public enum TableRow {
+    case columns([String])
+    case raw(String)
+  }
+
+  public enum Alignment {
+    case left
+    case right
+    case center
+  }
+
+  /// Output a table with each column nicely aligned.
+  ///
+  /// @param rows  An array of table rows, each of which holds an array
+  ///              of table columns.
+  ///
+  /// @result A `String` containing the formatted table.
+  public static func formatTable(_ rows: [TableRow],
+                                  alignments: [Alignment] = []) -> String {
+    // Work out how many columns we have
+    let colCount = rows.map{
+      if case let .columns(columns) = $0 {
+        return columns.count
+      } else {
+        return 0
+      }
+    }.reduce(0, max)
+
+    // Now compute their widths
+    var widths = Array(repeating: 0, count: colCount)
+    for row in rows {
+      if case let .columns(columns) = row {
+        for (n, width) in columns.lazy.map(measure).enumerated() {
+          widths[n] = max(widths[n], width)
+        }
+      }
+    }
+
+    // Generate lines for the table
+    var lines: [Substring] = []
+    for row in rows {
+      switch row {
+        case let .columns(columns):
+          let line = columns.enumerated().map{ n, column in
+            let alignment = n < alignments.count ? alignments[n] : .left
+            if n == colCount - 1 && alignment == .left {
+              return column
+            } else {
+              return pad(column, to: widths[n], aligned: alignment)
+            }
+          }.joined(separator: " ")
+
+          lines.append(rtrim(line))
+        case let .raw(line):
+          lines.append(rtrim(line))
+      }
+    }
+
+    // Trim any empty lines from the end
+    guard let lastNonEmpty = lines.lastIndex(where: { !$0.isEmpty }) else {
+      return ""
+    }
+
+    return lines.prefix(through: lastNonEmpty).joined(separator: "\n")
+  }
+
+  /// Format an individual frame into a list of columns.
+  ///
+  /// @param frame  The frame to format.
+  /// @param index  The frame index, if required.
+  ///
+  /// @result An array of strings, one per column.
+  public func formatColumns(frame: Backtrace.Frame,
+                            index: Int? = nil) -> [String] {
+    let pc: String
+    var attrs: [String] = []
+
+    switch frame {
+      case let .programCounter(address):
+        pc = "\(hex(address))"
+      case let .returnAddress(address):
+        pc = "\(hex(address))"
+        attrs.append("ra")
+      case let .asyncResumePoint(address):
+        pc = "\(hex(address))"
+        attrs.append("async")
+      case .omittedFrames(_), .truncated:
+        pc = "..."
+    }
+
+    var columns: [String] = []
+    if let index = index {
+      columns.append(options._theme.frameIndex("\(index)"))
+    }
+    columns.append(options._theme.programCounter(pc))
+    if options._showFrameAttributes {
+      columns.append(attrs.map(
+                       options._theme.frameAttribute
+                     ).joined(separator: " "))
+    }
+
+    return columns
+  }
+
+  /// Format a frame into a list of rows.
+  ///
+  /// @param frame  The frame to format.
+  /// @param index  The frame index, if required.
+  ///
+  /// @result An array of table rows.
+  public func formatRows(frame: Backtrace.Frame,
+                         index: Int? = nil) -> [TableRow] {
+    return [.columns(formatColumns(frame: frame, index: index))]
+  }
+
+  /// Format just one frame.
+  ///
+  /// @param frame   The frame to format.
+  /// @param index   (Optional) frame index.
+  ///
+  /// @result A `String` containing the formatted data.
+  public func format(frame: Backtrace.Frame, index: Int? = nil) -> String {
+    let rows = formatRows(frame: frame, index: index)
+    return BacktraceFormatter.formatTable(rows, alignments: [.right])
+  }
+
+  /// Format the frame list from a backtrace.
+  ///
+  /// @param frames  The frames to format.
+  ///
+  /// @result A `String` containing the formatted data.
+  public func format(frames: some Sequence<Backtrace.Frame>) -> String {
+    var rows: [TableRow] = []
+
+    var n = 0
+    for frame in frames {
+      rows += formatRows(frame: frame, index: n)
+
+      if case let .omittedFrames(count) = frame {
+        n += count
+      } else {
+        n += 1
+      }
+    }
+
+    return BacktraceFormatter.formatTable(rows, alignments: [.right])
+  }
+
+  /// Format a `Backtrace`
+  ///
+  /// @param backtrace  The `Backtrace` object to format.
+  ///
+  /// @result A `String` containing the formatted data.
+  public func format(backtrace: Backtrace) -> String {
+    return format(frames: backtrace.frames)
+  }
+
+  /// Grab source lines for a symbolicated backtrace.
+  ///
+  /// Tries to open the file corresponding to the symbol; if successful,
+  /// it will return a string containing the specified lines of context,
+  /// with the point at which the program crashed highlighted.
+  private func formattedSourceLines(from sourceLocation: SymbolicatedBacktrace.SourceLocation,
+                                    indent theIndent: Int = 2) -> String? {
+    guard let fp = fopen(sourceLocation.path, "rt") else { return nil }
+    defer {
+      fclose(fp)
+    }
+
+    let indent = String(repeating: " ", count: theIndent)
+    var lines: [String] = []
+    var line = 1
+    let buffer = UnsafeMutableBufferPointer<CChar>.allocate(capacity: 4096)
+    var currentLine = ""
+
+    let maxLine = sourceLocation.line + options._sourceContextLines
+    let maxLineWidth = max("\(maxLine)".count, 4)
+
+    let doLine = { sourceLine in
+      if line >= sourceLocation.line - options._sourceContextLines
+           && line <= sourceLocation.line + options._sourceContextLines {
+        let untabified = untabify(sourceLine)
+        let code = options._theme.code(untabified)
+        let lineNumber = options._theme.lineNumber(pad("\(line)",
+                                                       to: maxLineWidth,
+                                                       aligned: .right))
+        let theLine: String
+        if line == sourceLocation.line {
+          let highlightWidth = options._width - 2 * theIndent
+          theLine = options._theme.crashedLine(pad("\(lineNumber)│ \(code) ",
+                                                   to: highlightWidth))
+        } else {
+          theLine = "\(lineNumber)│ \(code)"
+        }
+        lines.append("\(indent)\(theLine)")
+
+        if line == sourceLocation.line {
+          // sourceLocation.column is an index in UTF-8 code units in
+          // `untabified`.  We should point at the grapheme cluster that
+          // contains that UTF-8 index.
+          let adjustedColumn = max(sourceLocation.column, 1)
+          let utf8Ndx
+            = untabified.utf8.index(untabified.utf8.startIndex,
+                                    offsetBy: adjustedColumn,
+                                    limitedBy: untabified.utf8.endIndex)
+            ?? untabified.utf8.endIndex
+
+          // Adjust it to point at a grapheme cluster start
+          let strNdx = untabified.index(
+            untabified.index(utf8Ndx, offsetBy: 1,
+                             limitedBy: untabified.endIndex)
+              ?? untabified.endIndex,
+            offsetBy: -1,
+            limitedBy: untabified.startIndex) ?? untabified.startIndex
+
+          // Work out the terminal width up to that point
+          let terminalWidth = measure(untabified.prefix(upTo: strNdx))
+
+          let pad = String(repeating: " ",
+                           count: max(terminalWidth - 1, 0))
+
+          let marker = options._theme.crashLocation("▲")
+          let blankForNumber = String(repeating: " ", count: maxLineWidth)
+
+          lines.append("\(indent)\(blankForNumber)│ \(pad)\(marker)")
+        }
+      }
+    }
+
+    while feof(fp) == 0 && ferror(fp) == 0 {
+      guard let result = fgets(buffer.baseAddress,
+                               Int32(buffer.count), fp) else {
+        break
+      }
+
+      let chunk = String(cString: result)
+      currentLine += chunk
+      if currentLine.hasSuffix("\n") {
+        currentLine.removeLast()
+        doLine(currentLine)
+        currentLine = ""
+        line += 1
+      }
+    }
+
+    doLine(currentLine)
+
+    return lines.joined(separator: "\n")
+  }
+
+  /// Format an individual frame into a list of columns.
+  ///
+  /// @params frame  The frame to format.
+  ///
+  /// @result An array of strings, one per column.
+  public func formatColumns(frame: SymbolicatedBacktrace.Frame,
+                            index: Int? = nil) -> [String] {
+    let pc: String
+    var attrs: [String] = []
+
+    switch frame.captured {
+      case let .programCounter(address):
+        pc = "\(hex(address))"
+      case let .returnAddress(address):
+        pc = "\(hex(address))"
+        attrs.append("ra")
+      case let .asyncResumePoint(address):
+        pc = "\(hex(address))"
+        attrs.append("async")
+      case .omittedFrames(_), .truncated:
+        pc = ""
+    }
+
+    if frame.inlined {
+      attrs.append("inlined")
+    }
+
+    if frame.isSwiftThunk {
+      attrs.append("thunk")
+    }
+
+    if frame.isSystem {
+      attrs.append("system")
+    }
+
+    var formattedSymbol: String? = nil
+    var hasSourceLocation = false
+
+    if let symbol = frame.symbol {
+      let displayName = options._demangle ? symbol.name : symbol.rawName
+      let themedName = options._theme.symbol(displayName)
+
+      let offset: String
+      if symbol.offset > 0 {
+        offset = options._theme.offset(" + \(symbol.offset)")
+      } else if symbol.offset < 0 {
+        offset = options._theme.offset(" - \(-symbol.offset)")
+      } else {
+        offset = ""
+      }
+
+      let imageName: String
+      if options._showImageNames {
+        if symbol.imageIndex >= 0 {
+          imageName = " in " + options._theme.imageName(symbol.imageName)
+        } else {
+          imageName = ""
+        }
+      } else {
+        imageName = ""
+      }
+
+      let location: String
+      if var sourceLocation = symbol.sourceLocation {
+        if options._sanitizePaths {
+          sourceLocation.path = sanitizePath(sourceLocation.path)
+        }
+        location = " at " + options._theme.sourceLocation("\(sourceLocation)")
+        hasSourceLocation = true
+      } else {
+        location = ""
+      }
+
+      formattedSymbol = "\(themedName)\(offset)\(imageName)\(location)"
+    }
+
+    let location: String
+    if !hasSourceLocation || options._showAddresses {
+      let formattedPc = options._theme.programCounter(pc)
+      if let formattedSymbol = formattedSymbol {
+        location = "\(formattedPc) \(formattedSymbol)"
+      } else {
+        location = formattedPc
+      }
+    } else if let formattedSymbol = formattedSymbol {
+      location = formattedSymbol
+    } else {
+      location = options._theme.programCounter(pc)
+    }
+
+    var columns: [String] = []
+
+    if let index = index {
+      let frameIndex: String
+      switch frame.captured {
+        case .omittedFrames(_), .truncated:
+          frameIndex = options._theme.frameIndex("...")
+        default:
+          frameIndex = options._theme.frameIndex("\(index)")
+      }
+      columns.append(frameIndex)
+    }
+
+    if options._showFrameAttributes {
+      columns.append(attrs.map(
+                       options._theme.frameAttribute
+                     ).joined(separator: " "))
+    }
+
+    columns.append(location)
+
+    return columns
+  }
+
+  /// Format a frame into a list of rows.
+  ///
+  /// @param frame  The frame to format.
+  /// @param index  The frame index, if required.
+  ///
+  /// @result An array of table rows.
+  public func formatRows(frame: SymbolicatedBacktrace.Frame,
+                         index: Int? = nil,
+                         showSource: Bool = true) -> [TableRow] {
+    let columns = formatColumns(frame: frame, index: index)
+    var rows: [TableRow] = [.columns(columns)]
+
+    if showSource {
+      if let symbol = frame.symbol,
+         let sourceLocation = symbol.sourceLocation,
+         let lines = formattedSourceLines(from: sourceLocation) {
+        rows.append(.raw(""))
+        rows.append(.raw(lines))
+        rows.append(.raw(""))
+      }
+    }
+
+    return rows
+  }
+
+  /// Format just one frame.
+  ///
+  /// @param frame   The frame to format.
+  /// @param index   (Optional) frame index.
+  ///
+  /// @result A `String` containing the formatted data.
+  public func format(frame: SymbolicatedBacktrace.Frame,
+                     index: Int? = nil,
+                     showSource: Bool = true) -> String {
+    let rows = formatRows(frame: frame, index: index, showSource: showSource)
+    return BacktraceFormatter.formatTable(rows, alignments: [.right])
+  }
+
+  /// Return `true` if we should skip the specified frame
+  public func shouldSkip(_ frame: SymbolicatedBacktrace.Frame) -> Bool {
+    return (options._skipRuntimeFailures && frame.isSwiftRuntimeFailure)
+      || (options._skipSystemFrames && frame.isSystem)
+      || (options._skipThunkFunctions && frame.isSwiftThunk)
+  }
+
+  /// Format the frame list from a symbolicated backtrace.
+  ///
+  /// @param frames  The frames to format.
+  ///
+  /// @result A `String` containing the formatted data.
+  public func format(frames: some Sequence<SymbolicatedBacktrace.Frame>) -> String {
+    var rows: [TableRow] = []
+    var sourceLocationsShown = Set<SymbolicatedBacktrace.SourceLocation>()
+
+    var n = 0
+    for frame in frames {
+      if shouldSkip(frame) {
+        continue
+      }
+
+      var showSource = options._showSourceCode
+      if let symbol = frame.symbol,
+         let sourceLocation = symbol.sourceLocation {
+        if sourceLocationsShown.contains(sourceLocation) {
+          showSource = false
+        } else {
+          sourceLocationsShown.insert(sourceLocation)
+        }
+      }
+
+      rows += formatRows(frame: frame, index: n, showSource: showSource)
+
+      if case let .omittedFrames(count) = frame.captured {
+        n += count
+      } else {
+        n += 1
+      }
+    }
+
+    return BacktraceFormatter.formatTable(rows, alignments: [.right])
+  }
+
+  /// Format a `SymbolicatedBacktrace`
+  ///
+  /// @param backtrace  The `SymbolicatedBacktrace` object to format.
+  ///
+  /// @result A `String` containing the formatted data.
+  public func format(backtrace: SymbolicatedBacktrace) -> String {
+    var result = format(frames: backtrace.frames)
+
+    switch options._showImages {
+      case .none:
+        break
+      case .all:
+        result += "\n\nImages:\n"
+        result += format(images: backtrace.images)
+      case .mentioned:
+        var mentionedImages = Set<Int>()
+        for frame in backtrace.frames {
+          if shouldSkip(frame) {
+            continue
+          }
+          if let symbol = frame.symbol, symbol.imageIndex >= 0 {
+            mentionedImages.insert(symbol.imageIndex)
+          }
+        }
+
+        let images = mentionedImages.sorted().map{ backtrace.images[$0] }
+        let omitted = backtrace.images.count - images.count
+        if omitted > 0 {
+          result += "\n\nImages (\(omitted) omitted):\n"
+        } else {
+          result += "\n\nImages (only mentioned):\n"
+        }
+        result += format(images: images)
+    }
+
+    return result
+  }
+
+  /// Format a `Backtrace.Image` into a list of columns.
+  ///
+  /// @param image  The `Image` object to format.
+  ///
+  /// @result An array of strings, one per column.
+  public func formatColumns(image: Backtrace.Image) -> [String] {
+    let addressRange = "\(hex(image.baseAddress))–\(hex(image.endOfText))"
+    let buildID: String
+    if let bytes = image.buildID {
+      buildID = hex(bytes)
+    } else {
+      buildID = "<no build ID>"
+    }
+    let imagePath: String
+    if options._sanitizePaths {
+      imagePath = sanitizePath(image.path)
+    } else {
+      imagePath = image.path
+    }
+    return [
+      options._theme.imageAddressRange(addressRange),
+      options._theme.imageBuildID(buildID),
+      options._theme.imageName(image.name),
+      options._theme.imagePath(imagePath)
+    ]
+  }
+
+  /// Format an array of `Backtrace.Image`s.
+  ///
+  /// @param images  The array of `Image` objects to format.
+  ///
+  /// @result A string containing the formatted data.
+  public func format(images: some Sequence<Backtrace.Image>) -> String {
+    let rows = images.map{ TableRow.columns(formatColumns(image: $0)) }
+
+    return BacktraceFormatter.formatTable(rows)
+  }
+}

--- a/stdlib/public/Backtracing/BacktraceFormatter.swift
+++ b/stdlib/public/Backtracing/BacktraceFormatter.swift
@@ -20,7 +20,7 @@ import Swift
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 @_implementationOnly import Darwin
 #elseif os(Windows)
-@_implementationOnly import MSVCRT
+@_implementationOnly import CRT
 #elseif os(Linux)
 @_implementationOnly import Glibc
 #endif

--- a/stdlib/public/Backtracing/BacktraceFormatter.swift
+++ b/stdlib/public/Backtracing/BacktraceFormatter.swift
@@ -294,11 +294,7 @@ private func measure(_ ch: Unicode.Scalar) -> Int {
     return 1
   }
 
-  if #available(macOS 10.12.2, *) {
-    if ch.properties.isEmoji {
-      return 2
-    }
-  } else if ch.value >= 0x1f100 && ch.value <= 0x1fb00 {
+  if ch.properties.isEmoji {
     return 2
   }
 

--- a/stdlib/public/Backtracing/BacktraceFormatter.swift
+++ b/stdlib/public/Backtracing/BacktraceFormatter.swift
@@ -690,7 +690,7 @@ public struct BacktraceFormatter {
 
     while feof(fp) == 0 && ferror(fp) == 0 {
       guard let result = fgets(buffer.baseAddress,
-                               Int32(buffer.count), fp) else {
+                               CInt(buffer.count), fp) else {
         break
       }
 

--- a/stdlib/public/Backtracing/CMakeLists.txt
+++ b/stdlib/public/Backtracing/CMakeLists.txt
@@ -1,0 +1,53 @@
+#===--- CMakeLists.txt - Backtracing support library -----------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2023 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===------------------------------------------------------------------------===#
+
+set(swift_backtracing_link_libraries
+  swiftCore
+)
+
+set(BACKTRACING_SOURCES
+  Backtrace.swift
+  BacktraceFormatter.swift
+  Context.swift
+  CoreSymbolication.swift
+  FramePointerUnwinder.swift
+  MemoryReader.swift
+  Registers.swift
+  SymbolicatedBacktrace.swift
+  Utils.swift
+
+  get-cpu-context.S
+)
+
+add_swift_target_library(swift_Backtracing ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  ${BACKTRACING_SOURCES}
+
+  SWIFT_MODULE_DEPENDS_IOS Darwin _Concurrency
+  SWIFT_MODULE_DEPENDS_OSX Darwin _Concurrency
+  SWIFT_MODULE_DEPENDS_TVOS Darwin _Concurrency
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin _Concurrency
+  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin _Concurrency
+  SWIFT_MODULE_DEPENDS_LINUX Glibc _Concurrency
+  SWIFT_MODULE_DEPENDS_WINDOWS CRT _Concurrency
+
+  LINK_LIBRARIES ${swift_backtracing_link_libraries}
+
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -parse-stdlib
+
+  LINK_FLAGS
+    ${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}
+
+  INSTALL_IN_COMPONENT stdlib
+  MACCATALYST_BUILD_FLAVOR "zippered"
+)

--- a/stdlib/public/Backtracing/CMakeLists.txt
+++ b/stdlib/public/Backtracing/CMakeLists.txt
@@ -25,7 +25,12 @@ set(BACKTRACING_SOURCES
   SymbolicatedBacktrace.swift
   Utils.swift
 
+  get-cpu-context.${SWIFT_ASM_EXT}
+)
+
+set(LLVM_OPTIONAL_SOURCES
   get-cpu-context.S
+  get-cpu-context.asm
 )
 
 add_swift_target_library(swift_Backtracing ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB

--- a/stdlib/public/Backtracing/Context.swift
+++ b/stdlib/public/Backtracing/Context.swift
@@ -1,0 +1,865 @@
+//===--- Context.swift - Unwind context structure -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the Context protocol and some concrete implementations for various
+// different types of CPU.
+//
+// Context holds register values during unwinding.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@_implementationOnly import _SwiftBacktracingShims
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@_implementationOnly import Darwin.Mach
+#endif
+
+@_spi(Contexts) public enum ContextError: Error {
+  case unableToFormTLSAddress
+}
+
+@_spi(Contexts) public protocol Context: CustomStringConvertible {
+  /// Represents a machine address for this type of machine
+  associatedtype Address: FixedWidthInteger
+
+  /// Represents a size for this type of machine
+  associatedtype Size: FixedWidthInteger
+
+  /// The type of a general purpose register on this machine
+  associatedtype GPRValue: FixedWidthInteger
+
+  /// An enumerated type defining the registers for the machine (this comes
+  /// from the architecture specific DWARF specification).
+  associatedtype Register: RawRepresentable where Register.RawValue == Int
+
+  /// The program counter; this is likely a return address
+  var programCounter: GPRValue { get set }
+
+  /// The stack pointer
+  var stackPointer: GPRValue { get set }
+
+  /// The frame pointer
+  var framePointer: GPRValue { get set }
+
+  /// The CFA as defined by the relevant architecture specific DWARF
+  /// specification.  For the architectures we have currently, it turns out
+  /// that this is the stack pointer, but it might in general be some other
+  /// thing.
+  var callFrameAddress: GPRValue { get set }
+
+  /// The number of register slots to reserve in the unwinder (this corresponds
+  /// to the DWARF register numbers, which is why some of these reserve a lot
+  /// of slots).
+  static var registerCount: Int { get }
+
+  /// Given a thread local address, form a genuine machine address
+  func formTLSAddress(threadLocal: Address) throws -> Address
+
+  /// Get the value of the specified general purpose register, or nil if unknown
+  func getRegister(_ register: Register) -> GPRValue?
+
+  /// Set the value of the specified general purpose register (or mark it as
+  /// unknown if nil is passed)
+  mutating func setRegister(_ register: Register, to value: GPRValue?)
+
+  /// Set all of the registers in bulk
+  mutating func setRegisters(_ registers: [GPRValue?])
+
+  /// Strip any pointer authentication that might apply from an address.
+  static func stripPtrAuth(address: Address) -> Address
+
+  /// Test if an address is appropriately aligned for the stack.
+  static func isAlignedForStack(framePointer: Address) -> Bool
+}
+
+extension Context {
+  public func formTLSAddress(threadLocal: Address) throws -> Address {
+    throw ContextError.unableToFormTLSAddress
+  }
+
+  public mutating func setRegisters(_ registers: [GPRValue?]) {
+    for (ndx, value) in registers.enumerated() {
+      if let reg = Register(rawValue: ndx) {
+        setRegister(reg, to: value)
+      }
+    }
+  }
+
+  public static func stripPtrAuth(address: Address) -> Address {
+    return address
+  }
+}
+
+// .. Extensions to the GPR structures .........................................
+
+// We need these because the arrays in the _gprs structs (which are defined
+// in C so that the layout is fixed) get imported as tuples.
+
+extension x86_64_gprs {
+  func getR(_ ndx: Int) -> UInt64 {
+    return withUnsafePointer(to: _r) {
+      $0.withMemoryRebound(to: UInt64.self, capacity: 16) {
+        $0[ndx]
+      }
+    }
+  }
+
+  mutating func setR(_ ndx: Int, to value: UInt64) {
+    withUnsafeMutablePointer(to: &_r) {
+      $0.withMemoryRebound(to: UInt64.self, capacity: 16) {
+        $0[ndx] = value
+      }
+    }
+    valid |= 1 << ndx
+  }
+}
+
+extension i386_gprs {
+  func getR(_ ndx: Int) -> UInt32 {
+    return withUnsafePointer(to: _r) {
+      $0.withMemoryRebound(to: UInt32.self, capacity: 8) {
+        $0[ndx]
+      }
+    }
+  }
+
+  mutating func setR(_ ndx: Int, to value: UInt32) {
+    withUnsafeMutablePointer(to: &_r) {
+      $0.withMemoryRebound(to: UInt32.self, capacity: 8) {
+        $0[ndx] = value
+      }
+    }
+    valid |= 1 << ndx
+  }
+}
+
+extension arm64_gprs {
+  func getX(_ ndx: Int) -> UInt64 {
+    return withUnsafePointer(to: _x) {
+      $0.withMemoryRebound(to: UInt64.self, capacity: 32) {
+        $0[ndx]
+      }
+    }
+  }
+
+  mutating func setX(_ ndx: Int, to value: UInt64) {
+    withUnsafeMutablePointer(to: &_x) {
+      $0.withMemoryRebound(to: UInt64.self, capacity: 32) {
+        $0[ndx] = value
+      }
+    }
+    valid |= 1 << ndx
+  }
+}
+
+extension arm_gprs {
+  func getR(_ ndx: Int) -> UInt32 {
+    return withUnsafePointer(to: _r) {
+      $0.withMemoryRebound(to: UInt32.self, capacity: 16) {
+        $0[ndx]
+      }
+    }
+  }
+
+  mutating func setR(_ ndx: Int, to value: UInt32) {
+    withUnsafeMutablePointer(to: &_r) {
+      $0.withMemoryRebound(to: UInt32.self, capacity: 16) {
+        $0[ndx] = value
+      }
+    }
+    valid |= 1 << ndx
+  }
+}
+
+// .. x86-64 ...................................................................
+
+@_spi(Contexts) public struct X86_64Context: Context {
+  public typealias Address = UInt64
+  public typealias Size = UInt64
+  public typealias GPRValue = UInt64
+  public typealias Register = X86_64Register
+
+  var gprs = x86_64_gprs()
+
+  public var programCounter: Address {
+    get { return gprs.rip }
+    set {
+      gprs.rip = newValue
+      gprs.valid |= 1 << 20
+    }
+  }
+  public var framePointer: Address {
+    get { return gprs.getR(X86_64Register.rbp.rawValue) }
+    set {
+      gprs.setR(X86_64Register.rbp.rawValue, to: newValue)
+    }
+  }
+  public var stackPointer: Address {
+    get { return gprs.getR(X86_64Register.rsp.rawValue) }
+    set {
+      gprs.setR(X86_64Register.rsp.rawValue, to: newValue)
+    }
+  }
+
+  public var callFrameAddress: GPRValue {
+    get { return stackPointer }
+    set { stackPointer = newValue }
+  }
+
+  public static var registerCount: Int { return 56 }
+
+  #if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && arch(x86_64)
+  init?(from thread: thread_t) {
+    var state = darwin_x86_64_thread_state()
+    let kr = mach_thread_get_state(thread, x86_THREAD_STATE64, &state)
+    if kr != KERN_SUCCESS {
+      return nil
+    }
+
+    self.init(from: state)
+  }
+
+  init(with mctx: darwin_x86_64_mcontext) {
+    self.init(from: mctx.ss)
+  }
+
+  init(from state: darwin_x86_64_thread_state) {
+    gprs.setR(X86_64Register.rax.rawValue, to: state.rax)
+    gprs.setR(X86_64Register.rbx.rawValue, to: state.rbx)
+    gprs.setR(X86_64Register.rcx.rawValue, to: state.rcx)
+    gprs.setR(X86_64Register.rdx.rawValue, to: state.rdx)
+    gprs.setR(X86_64Register.rdi.rawValue, to: state.rdi)
+    gprs.setR(X86_64Register.rsi.rawValue, to: state.rsi)
+    gprs.setR(X86_64Register.rbp.rawValue, to: state.rbp)
+    gprs.setR(X86_64Register.rsp.rawValue, to: state.rsp)
+    gprs.setR(X86_64Register.r8.rawValue, to: state.r8)
+    gprs.setR(X86_64Register.r9.rawValue, to: state.r9)
+    gprs.setR(X86_64Register.r10.rawValue, to: state.r10)
+    gprs.setR(X86_64Register.r11.rawValue, to: state.r11)
+    gprs.setR(X86_64Register.r12.rawValue, to: state.r12)
+    gprs.setR(X86_64Register.r13.rawValue, to: state.r13)
+    gprs.setR(X86_64Register.r14.rawValue, to: state.r14)
+    gprs.setR(X86_64Register.r15.rawValue, to: state.r15)
+    gprs.rip = state.rip
+    gprs.rflags = state.rflags
+    gprs.cs = UInt16(state.cs)
+    gprs.fs = UInt16(state.fs)
+    gprs.gs = UInt16(state.gs)
+    gprs.valid = 0x1fffff
+  }
+
+  public static func fromHostThread(_ thread: Any) -> HostContext? {
+    return X86_64Context(from: thread as! thread_t)
+  }
+
+  public static func fromHostMContext(_ mcontext: Any) -> HostContext {
+    return X86_64Context(with: mcontext as! darwin_x86_64_mcontext)
+  }
+  #endif
+
+  #if arch(x86_64)
+  @_silgen_name("_swift_get_cpu_context")
+  static func _swift_get_cpu_context() -> X86_64Context
+
+  public static func withCurrentContext<T>(fn: (X86_64Context) throws -> T) rethrows -> T {
+    return try fn(_swift_get_cpu_context())
+  }
+  #endif
+
+  private func validNdx(_ register: Register) -> Int? {
+    switch register {
+      case .rax ... .r15:
+        return register.rawValue
+      case .rflags:
+        return 16
+      case .cs:
+        return 17
+      case .fs:
+        return 18
+      case .gs:
+        return 19
+      default:
+        return nil
+    }
+  }
+
+  private func isValid(_ register: Register) -> Bool {
+    guard let ndx = validNdx(register) else {
+      return false
+    }
+    return (gprs.valid & (UInt64(1) << ndx)) != 0
+  }
+
+  private mutating func setValid(_ register: Register) {
+    guard let ndx = validNdx(register) else {
+      return
+    }
+    gprs.valid |= UInt64(1) << ndx
+  }
+
+  private mutating func clearValid(_ register: Register) {
+    guard let ndx = validNdx(register) else {
+      return
+    }
+    gprs.valid &= ~(UInt64(1) << ndx)
+  }
+
+  public func getRegister(_ register: Register) -> GPRValue? {
+    if !isValid(register) {
+      return nil
+    }
+
+    switch register {
+      case .rax ... .r15:
+        return gprs.getR(register.rawValue)
+      case .rflags: return gprs.rflags
+      case .cs: return UInt64(gprs.cs)
+      case .fs: return UInt64(gprs.fs)
+      case .gs: return UInt64(gprs.gs)
+      default:
+        return nil
+    }
+  }
+
+  public mutating func setRegister(_ register: Register, to value: GPRValue?) {
+    if let value = value {
+      switch register {
+        case .rax ... .r15:
+          gprs.setR(register.rawValue, to: value)
+        case .rflags:
+          gprs.rflags = value
+          setValid(register)
+        case .cs:
+          gprs.cs = UInt16(value)
+          setValid(register)
+        case .fs:
+          gprs.fs = UInt16(value)
+          setValid(register)
+        case .gs:
+          gprs.gs = UInt16(value)
+          setValid(register)
+        default:
+          return
+      }
+    } else {
+      clearValid(register)
+    }
+  }
+
+  public var description: String {
+    return """
+      rax: \(hex(gprs.getR(0))) rbx: \(hex(gprs.getR(3))) rcx: \(hex(gprs.getR(2)))
+      rdx: \(hex(gprs.getR(1))) rsi: \(hex(gprs.getR(4))) rdi: \(hex(gprs.getR(5)))
+      rbp: \(hex(gprs.getR(6))) rsp: \(hex(gprs.getR(7)))  r8: \(hex(gprs.getR(8)))
+       r9: \(hex(gprs.getR(9))) r10: \(hex(gprs.getR(10))) r11: \(hex(gprs.getR(11)))
+      r12: \(hex(gprs.getR(12))) r13: \(hex(gprs.getR(13))) r14: \(hex(gprs.getR(14)))
+      r15: \(hex(gprs.getR(15)))
+
+       cs: \(hex(gprs.cs))  fs: \(hex(gprs.fs))  gs: \(hex(gprs.gs))
+
+      rip: \(hex(gprs.rip)) rflags: \(hex(gprs.rflags))
+      """
+  }
+
+  public static func isAlignedForStack(framePointer: Address) -> Bool {
+    return (framePointer & 0xf) == 0
+  }
+
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  internal static var coreSymbolicationArchitecture: CSArchitecture {
+    return kCSArchitectureX86_64
+  }
+  #endif
+}
+
+// .. i386 .....................................................................
+
+@_spi(Contexts) public struct I386Context: Context {
+  public typealias Address = UInt32
+  public typealias Size = UInt32
+  public typealias GPRValue = UInt32
+  public typealias Register = I386Register
+
+  var gprs = i386_gprs()
+
+  public var programCounter: GPRValue {
+    get { return gprs.eip }
+    set {
+      gprs.eip = newValue
+      gprs.valid |= 1 << 15
+    }
+  }
+
+  public var framePointer: GPRValue {
+    get { return gprs.getR(I386Register.ebp.rawValue) }
+    set { gprs.setR(I386Register.ebp.rawValue, to: newValue) }
+  }
+
+  public var stackPointer: GPRValue {
+    get { return gprs.getR(I386Register.esp.rawValue) }
+    set { gprs.setR(I386Register.esp.rawValue, to: newValue) }
+  }
+
+  public var callFrameAddress: GPRValue {
+    get { return stackPointer }
+    set { stackPointer = newValue }
+  }
+
+  public static var registerCount: Int { return 50 }
+
+  #if arch(i386)
+  @_silgen_name("_swift_get_cpu_context")
+  static func _swift_get_cpu_context() -> I386Context
+
+  public static func withCurrentContext<T>(fn: (I386Context) throws -> T) rethrows -> T {
+    return try fn(_swift_get_cpu_context())
+  }
+  #endif
+
+  private func validNdx(_ register: Register) -> Int? {
+    switch register {
+      case .eax ... .edi:
+        return register.rawValue
+      case .eflags:
+        return 8
+      case .es, .cs, .ss, .ds, .fs, .gs:
+        return 9 + register.rawValue - Register.es.rawValue
+      case .ra:
+        return 15
+      default:
+        return nil
+    }
+  }
+
+  private func isValid(_ register: Register) -> Bool {
+    guard let ndx = validNdx(register) else {
+      return false
+    }
+    return (gprs.valid & (UInt32(1) << ndx)) != 0
+  }
+
+  private mutating func setValid(_ register: Register) {
+    guard let ndx = validNdx(register) else {
+      return
+    }
+    gprs.valid |= UInt32(1) << ndx
+  }
+
+  private mutating func clearValid(_ register: Register) {
+    guard let ndx = validNdx(register) else {
+      return
+    }
+    gprs.valid &= ~(UInt32(1) << ndx)
+  }
+
+  public func getRegister(_ register: Register) -> GPRValue? {
+    if !isValid(register) {
+      return nil
+    }
+    switch register {
+      case .eax ... .edi:
+        return gprs.getR(register.rawValue)
+      case .eflags: return gprs.eflags
+      case .es ... .gs:
+        return withUnsafeBytes(of: gprs.segreg) { ptr in
+          return ptr.withMemoryRebound(to: GPRValue.self) { regs in
+            return regs[register.rawValue - Register.es.rawValue]
+          }
+        }
+      case .ra: return gprs.eip
+      default:
+        return nil
+    }
+  }
+
+  public mutating func setRegister(_ register: Register, to value: GPRValue?) {
+    if let value = value {
+      switch register {
+        case .eax ... .edi:
+          gprs.setR(register.rawValue, to: value)
+        case .eflags:
+          gprs.eflags = value
+          setValid(register)
+        case .es ... .gs:
+          withUnsafeMutableBytes(of: &gprs.segreg) { ptr in
+            ptr.withMemoryRebound(to: GPRValue.self) { regs in
+              regs[register.rawValue - Register.es.rawValue] = value
+            }
+          }
+          setValid(register)
+        case .ra:
+          gprs.eip = value
+          setValid(register)
+        default:
+          return
+      }
+    } else {
+      clearValid(register)
+    }
+  }
+
+  public var description: String {
+    return """
+      eax: \(hex(gprs.getR(0))) ebx: \(hex(gprs.getR(3))) ecx: \(hex(gprs.getR(1))) edx: \(hex(gprs.getR(2)))
+      esi: \(hex(gprs.getR(6))) edi: \(hex(gprs.getR(7))) ebp: \(hex(gprs.getR(5))) esp: \(hex(gprs.getR(4)))
+
+      es: \(hex(gprs.segreg.0)) cs: \(hex(gprs.segreg.1)) ss: \(hex(gprs.segreg.2)) ds: \(hex(gprs.segreg.3)) fs: \(hex(gprs.segreg.4)) gs: \(hex(gprs.segreg.5))
+
+      eip: \(hex(gprs.eip)) eflags: \(hex(gprs.eflags))
+      """
+  }
+
+  public static func isAlignedForStack(framePointer: Address) -> Bool {
+    return (framePointer & 0xf) == 8
+  }
+
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  internal static var coreSymbolicationArchitecture: CSArchitecture {
+    return kCSArchitectureI386
+  }
+  #endif
+}
+
+// .. ARM64 ....................................................................
+
+@_spi(Contexts) public struct ARM64Context: Context {
+  public typealias Address = UInt64
+  public typealias Size = UInt64
+  public typealias GPRValue = UInt64
+  public typealias Register = ARM64Register
+
+  var gprs = arm64_gprs()
+
+  public var programCounter: GPRValue {
+    get { return gprs.pc }
+    set {
+      gprs.pc = newValue
+      gprs.valid |= 1 << 32
+    }
+  }
+
+  public var stackPointer: GPRValue {
+    get { return gprs.getX(ARM64Register.sp.rawValue) }
+    set {
+      gprs.setX(ARM64Register.sp.rawValue, to: newValue)
+    }
+  }
+
+  public var framePointer: GPRValue {
+    get { return gprs.getX(ARM64Register.x29.rawValue) }
+    set {
+      gprs.setX(ARM64Register.x29.rawValue, to: newValue)
+    }
+  }
+
+  public var callFrameAddress: GPRValue {
+    get { return stackPointer }
+    set { stackPointer = newValue }
+  }
+
+  public static var registerCount: Int { return 40 }
+
+  #if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && arch(arm64)
+  init?(from thread: thread_t) {
+    var state = darwin_arm64_thread_state()
+    let kr = mach_thread_get_state(thread, ARM_THREAD_STATE64, &state)
+    if kr != KERN_SUCCESS {
+      return nil
+    }
+
+    self.init(from: state)
+  }
+
+  init(with mctx: darwin_arm64_mcontext) {
+    self.init(from: mctx.ss)
+  }
+
+  init(from state: darwin_arm64_thread_state) {
+    withUnsafeMutablePointer(to: &gprs._x) {
+      $0.withMemoryRebound(to: UInt64.self, capacity: 32){ to in
+        withUnsafePointer(to: state._x) {
+          $0.withMemoryRebound(to: UInt64.self, capacity: 29){ from in
+            for n in 0..<29 {
+              to[n] = from[n]
+            }
+          }
+        }
+
+        to[29] = state.fp
+        to[30] = state.lr
+        to[31] = state.sp
+      }
+    }
+    gprs.pc = state.pc
+    gprs.valid = 0x1ffffffff
+  }
+
+  public static func fromHostThread(_ thread: Any) -> HostContext? {
+    return ARM64Context(from: thread as! thread_t)
+  }
+
+  public static func fromHostMContext(_ mcontext: Any) -> HostContext {
+    return ARM64Context(with: mcontext as! darwin_arm64_mcontext)
+  }
+#endif
+
+  #if arch(arm64)
+  @_silgen_name("_swift_get_cpu_context")
+  static func _swift_get_cpu_context() -> ARM64Context
+
+  public static func withCurrentContext<T>(fn: (ARM64Context) throws -> T) rethrows -> T {
+    return try fn(_swift_get_cpu_context())
+  }
+  #endif
+
+  private func isValid(_ register: Register) -> Bool {
+    if register.rawValue < 33 {
+      return (gprs.valid & (UInt64(1) << register.rawValue)) != 0
+    }
+    return false
+  }
+
+  private mutating func setValid(_ register: Register) {
+    if register.rawValue < 33 {
+      gprs.valid |= UInt64(1) << register.rawValue
+    }
+  }
+
+  private mutating func clearValid(_ register: Register) {
+    if register.rawValue < 33 {
+      gprs.valid &= ~(UInt64(1) << register.rawValue)
+    }
+  }
+
+  public func getRegister(_ reg: Register) -> GPRValue? {
+    if !isValid(reg) {
+      return nil
+    }
+    switch reg {
+      case .x0 ... .sp:
+        return gprs.getX(reg.rawValue)
+      case .pc:
+        return gprs.pc
+      default:
+        return nil
+    }
+  }
+
+  public mutating func setRegister(_ reg: Register, to value: GPRValue?) {
+    if let value = value {
+      switch reg {
+        case .x0 ... .sp:
+          gprs.setX(reg.rawValue, to: value)
+        case .pc:
+          gprs.pc = value
+          setValid(reg)
+        default:
+          break
+      }
+    } else {
+      clearValid(reg)
+    }
+  }
+
+  public var description: String {
+    return """
+       x0: \(hex(gprs.getX(0)))  x1: \(hex(gprs.getX(1)))
+       x2: \(hex(gprs.getX(2)))  x3: \(hex(gprs.getX(3)))
+       x4: \(hex(gprs.getX(4)))  x5: \(hex(gprs.getX(5)))
+       x6: \(hex(gprs.getX(6)))  x7: \(hex(gprs.getX(7)))
+       x8: \(hex(gprs.getX(8)))  x9: \(hex(gprs.getX(9)))
+      x10: \(hex(gprs.getX(10))) x11: \(hex(gprs.getX(11)))
+      x12: \(hex(gprs.getX(12))) x13: \(hex(gprs.getX(13)))
+      x14: \(hex(gprs.getX(14))) x15: \(hex(gprs.getX(15)))
+      x16: \(hex(gprs.getX(16))) x17: \(hex(gprs.getX(17)))
+      x18: \(hex(gprs.getX(18))) x19: \(hex(gprs.getX(19)))
+      x20: \(hex(gprs.getX(20))) x21: \(hex(gprs.getX(21)))
+      x22: \(hex(gprs.getX(22))) x23: \(hex(gprs.getX(23)))
+      x24: \(hex(gprs.getX(24))) x25: \(hex(gprs.getX(25)))
+      x26: \(hex(gprs.getX(26))) x27: \(hex(gprs.getX(27)))
+      x28: \(hex(gprs.getX(28)))
+
+      fp: \(hex(gprs.getX(29))) (aka x29)
+      lr: \(hex(gprs.getX(30))) (aka x30)
+      sp: \(hex(gprs.getX(31))) (aka x31)
+
+      pc: \(hex(gprs.pc))
+      """
+  }
+
+  public static func isAlignedForStack(framePointer: Address) -> Bool {
+    return (framePointer & 1) == 0
+  }
+
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  public static func stripPtrAuth(address: Address) -> Address {
+    // Is there a better way to do this?  It'd be easy if we just wanted to
+    // strip for the *host*, but we might conceivably want this under other
+    // circumstances too.
+    return address & 0x00007fffffffffff
+  }
+
+  internal static var coreSymbolicationArchitecture: CSArchitecture {
+    return kCSArchitectureArm64
+  }
+  #endif
+}
+
+// .. 32-bit ARM ...............................................................
+
+@_spi(Contexts) public struct ARMContext: Context {
+  public typealias Address = UInt32
+  public typealias Size = UInt32
+  public typealias GPRValue = UInt32
+  public typealias Register = ARMRegister
+
+  var gprs = arm_gprs()
+
+  public var programCounter: GPRValue {
+    get { return gprs.getR(ARMRegister.r15.rawValue) }
+    set { gprs.setR(ARMRegister.r15.rawValue, to: newValue) }
+  }
+
+  public var stackPointer: GPRValue {
+    get { return gprs.getR(ARMRegister.r13.rawValue) }
+    set { gprs.setR(ARMRegister.r13.rawValue, to: newValue) }
+  }
+
+  public var framePointer: GPRValue {
+    get { return gprs.getR(ARMRegister.r11.rawValue) }
+    set { gprs.setR(ARMRegister.r11.rawValue, to: newValue) }
+  }
+
+  public var callFrameAddress: GPRValue {
+    get { return stackPointer }
+    set { stackPointer = newValue }
+  }
+
+  public static var registerCount: Int { return 16 }
+
+#if arch(arm)
+  @_silgen_name("_swift_get_cpu_context")
+  static func _swift_get_cpu_context() -> ARMContext
+
+  public static func withCurrentContext<T>(fn: (ARMContext) throws -> T) rethrows -> T {
+    return try fn(_swift_get_cpu_context())
+  }
+#endif
+
+  private func isValid(_ register: Register) -> Bool {
+    if register.rawValue < 16 {
+      return (gprs.valid & (UInt32(1) << register.rawValue)) != 0
+    }
+    return false
+  }
+
+  private mutating func setValid(_ register: Register) {
+    if register.rawValue < 16 {
+      gprs.valid |= UInt32(1) << register.rawValue
+    }
+  }
+
+  private mutating func clearValid(_ register: Register) {
+    if register.rawValue < 16 {
+      gprs.valid &= ~(UInt32(1) << register.rawValue)
+    }
+  }
+
+  public func getRegister(_ reg: Register) -> GPRValue? {
+    if !isValid(reg) {
+      return nil
+    }
+    switch reg {
+      case .r0 ... .r15:
+        return gprs.getR(reg.rawValue)
+      default:
+        return nil
+    }
+  }
+
+  public mutating func setRegister(_ reg: Register, to value: GPRValue?) {
+    if let value = value {
+      switch reg {
+        case .r0 ... .r15:
+          gprs.setR(reg.rawValue, to: value)
+        default:
+          break
+      }
+    } else {
+      clearValid(reg)
+    }
+  }
+
+  public var description: String {
+    return """
+       r0: \(hex(gprs.getR(0)))  r1: \(hex(gprs.getR(1)))
+       r2: \(hex(gprs.getR(2)))  r3: \(hex(gprs.getR(3)))
+       r4: \(hex(gprs.getR(4)))  r5: \(hex(gprs.getR(5)))
+       r6: \(hex(gprs.getR(6)))  r7: \(hex(gprs.getR(7)))
+       r8: \(hex(gprs.getR(8)))  r9: \(hex(gprs.getR(9)))
+      r10: \(hex(gprs.getR(10)))
+
+       fp: \(hex(gprs.getR(11))) (aka r11)
+       ip: \(hex(gprs.getR(12))) (aka r12)
+       sp: \(hex(gprs.getR(13))) (aka r13)
+       lr: \(hex(gprs.getR(14))) (aka r14)
+       pc: \(hex(gprs.getR(15))) (aka r15)
+      """
+  }
+
+  public static func isAlignedForStack(framePointer: Address) -> Bool {
+    return (framePointer & 1) == 0
+  }
+
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  internal static var coreSymbolicationArchitecture: CSArchitecture {
+    return kCSArchitectureArmV7K
+  }
+  #endif
+}
+
+// .. Darwin specifics .........................................................
+
+#if os(macOS)
+private func mach_thread_get_state<T>(_ thread: thread_t,
+                                      _ flavor: CInt,
+                                      _ result: inout T) -> kern_return_t {
+  var count: mach_msg_type_number_t
+    = mach_msg_type_number_t(MemoryLayout<T>.stride
+                               / MemoryLayout<natural_t>.stride)
+
+  return withUnsafeMutablePointer(to: &result) { ptr in
+    ptr.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { intPtr in
+      return thread_get_state(thread,
+                              thread_state_flavor_t(flavor),
+                              intPtr,
+                              &count)
+    }
+  }
+}
+#endif
+
+// .. HostContext ..............................................................
+
+/// HostContext is an alias for the appropriate context for the machine on which
+/// the code was compiled.
+#if arch(x86_64)
+@_spi(Contexts) public typealias HostContext = X86_64Context
+#elseif arch(i386)
+@_spi(Contexts) public typealias HostContext = I386Context
+#elseif arch(arm64)
+@_spi(Contexts) public typealias HostContext = ARM64Context
+#elseif arch(arm)
+@_spi(Contexts) public typealias HostContext = ARMContext
+#endif

--- a/stdlib/public/Backtracing/Context.swift
+++ b/stdlib/public/Backtracing/Context.swift
@@ -831,7 +831,7 @@ extension arm_gprs {
 
 // .. Darwin specifics .........................................................
 
-#if os(macOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 private func mach_thread_get_state<T>(_ thread: thread_t,
                                       _ flavor: CInt,
                                       _ result: inout T) -> kern_return_t {

--- a/stdlib/public/Backtracing/CoreSymbolication.swift
+++ b/stdlib/public/Backtracing/CoreSymbolication.swift
@@ -1,0 +1,360 @@
+//===--- CoreSymbolication.swift - Shims for CoreSymbolication ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// CoreSymbolication is a private framework, which makes it tricky to link
+// with from here and also means there are no headers on customer builds.
+//
+//===----------------------------------------------------------------------===//
+
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+
+import Swift
+
+@_implementationOnly import Darwin
+@_implementationOnly import CoreFoundation
+
+@_implementationOnly import _SwiftBacktracingShims
+
+// .. Dynamic binding ..........................................................
+
+private let coreSymbolicationPath =
+  "/System/Library/PrivateFrameworks/CoreSymbolication.framework/CoreSymbolication"
+private let coreSymbolicationHandle = dlopen(coreSymbolicationPath, RTLD_LAZY)!
+
+private let crashReporterSupportPath =
+  "/System/Library/PrivateFrameworks/CrashReporterSupport.framework/CrashReporterSupport"
+
+private let crashReporterSupportHandle = dlopen(crashReporterSupportPath, RTLD_LAZY)!
+
+private func symbol<T>(_ handle: UnsafeMutableRawPointer, _ name: String) -> T {
+  guard let result = dlsym(handle, name) else {
+    fatalError("Unable to look up \(name) in CoreSymbolication")
+  }
+  return unsafeBitCast(result, to: T.self)
+}
+
+private enum Sym {
+  // CRCopySanitizedPath
+  static let CRCopySanitizedPath: @convention(c) (CFString, CFIndex) -> CFString =
+    symbol(crashReporterSupportHandle, "CRCopySanitizedPath")
+
+  // Base functionality
+  static let CSRetain: @convention(c) (CSTypeRef) -> CSTypeRef =
+    symbol(coreSymbolicationHandle, "CSRetain")
+  static let CSRelease: @convention(c) (CSTypeRef) -> () =
+    symbol(coreSymbolicationHandle, "CSRelease")
+  static let CSEqual: @convention(c) (CSTypeRef, CSTypeRef) -> CBool =
+    symbol(coreSymbolicationHandle, "CSEqual")
+  static let CSIsNull: @convention(c) (CSTypeRef) -> CBool =
+    symbol(coreSymbolicationHandle, "CSIsNull")
+
+  // CSSymbolicator
+  static let CSSymbolicatorCreateWithBinaryImageList:
+    @convention(c) (UnsafeMutablePointer<CSBinaryImageInformation>,
+                    UInt32, UInt32, CSNotificationBlock?) -> CSSymbolicatorRef =
+    symbol(coreSymbolicationHandle, "CSSymbolicatorCreateWithBinaryImageList")
+
+  static let CSSymbolicatorGetSymbolOwnerWithAddressAtTime:
+    @convention(c) (CSSymbolicatorRef, mach_vm_address_t,
+                    CSMachineTime) -> CSSymbolOwnerRef =
+    symbol(coreSymbolicationHandle, "CSSymbolicatorGetSymbolOwnerWithAddressAtTime")
+  static let CSSymbolicatorForeachSymbolOwnerAtTime:
+    @convention(c) (CSSymbolicatorRef, CSMachineTime, @convention(block) (CSSymbolOwnerRef) -> Void) -> UInt =
+      symbol(coreSymbolicationHandle, "CSSymbolicatorForeachSymbolOwnerAtTime")
+
+  // CSSymbolOwner
+  static let CSSymbolOwnerGetName:
+    @convention(c) (CSSymbolOwnerRef) -> UnsafePointer<CChar>? =
+    symbol(coreSymbolicationHandle, "CSSymbolOwnerGetName")
+  static let CSSymbolOwnerGetSymbolWithAddress:
+    @convention(c) (CSSymbolOwnerRef, mach_vm_address_t) -> CSSymbolRef =
+    symbol(coreSymbolicationHandle, "CSSymbolOwnerGetSymbolWithAddress")
+  static let CSSymbolOwnerGetSourceInfoWithAddress:
+    @convention(c) (CSSymbolOwnerRef, mach_vm_address_t) -> CSSourceInfoRef =
+    symbol(coreSymbolicationHandle, "CSSymbolOwnerGetSourceInfoWithAddress")
+  static let CSSymbolOwnerForEachStackFrameAtAddress:
+    @convention(c) (CSSymbolOwnerRef, mach_vm_address_t, CSStackFrameIterator) -> UInt =
+    symbol(coreSymbolicationHandle, "CSSymbolOwnerForEachStackFrameAtAddress")
+  static let CSSymbolOwnerGetBaseAddress:
+    @convention(c) (CSSymbolOwnerRef) -> mach_vm_address_t =
+    symbol(coreSymbolicationHandle, "CSSymbolOwnerGetBaseAddress")
+
+  // CSSymbol
+  static let CSSymbolGetRange:
+    @convention(c) (CSSymbolRef) -> CSRange =
+    symbol(coreSymbolicationHandle, "CSSymbolGetRange")
+  static let CSSymbolGetName:
+    @convention(c) (CSSymbolRef) -> UnsafePointer<CChar>? =
+    symbol(coreSymbolicationHandle, "CSSymbolGetName")
+  static let CSSymbolGetMangledName:
+    @convention(c) (CSSymbolRef) -> UnsafePointer<CChar>? =
+    symbol(coreSymbolicationHandle, "CSSymbolGetMangledName")
+
+  // CSSourceInfo
+  static let CSSourceInfoGetPath:
+    @convention(c) (CSSourceInfoRef) -> UnsafePointer<CChar>? =
+    symbol(coreSymbolicationHandle, "CSSourceInfoGetPath")
+  static let CSSourceInfoGetLineNumber:
+    @convention(c) (CSSourceInfoRef) -> UInt32 =
+    symbol(coreSymbolicationHandle, "CSSourceInfoGetLineNumber")
+  static let CSSourceInfoGetColumn:
+    @convention(c) (CSSourceInfoRef) -> UInt32 =
+    symbol(coreSymbolicationHandle, "CSSourceInfoGetColumn")
+}
+
+// .. Crash Reporter support ...................................................
+
+// We can't import swiftFoundation here, so there's no automatic bridging for
+// CFString.  As a result, we need to do the dance manually.
+
+private func toCFString(_ s: String) -> CFString! {
+  let bytes = Array<UInt8>(s.utf8)
+  return bytes.withUnsafeBufferPointer{
+    return CFStringCreateWithBytes(nil,
+                                   $0.baseAddress,
+                                   $0.count,
+                                   CFStringBuiltInEncodings.UTF8.rawValue,
+                                   false)
+  }
+}
+
+private func fromCFString(_ cf: CFString) -> String {
+  let length = CFStringGetLength(cf)
+  if length == 0 {
+    return ""
+  }
+
+  if let ptr = CFStringGetCStringPtr(cf,
+                                     CFStringBuiltInEncodings.ASCII.rawValue) {
+    return ptr.withMemoryRebound(to: UInt8.self, capacity: length) {
+      return String(decoding: UnsafeBufferPointer(start: $0, count: length),
+                    as: UTF8.self)
+    }
+  } else {
+    var byteLen = CFIndex(0)
+
+    CFStringGetBytes(cf,
+                     CFRangeMake(0, length),
+                     CFStringBuiltInEncodings.UTF8.rawValue,
+                     0,
+                     false,
+                     nil,
+                     0,
+                     &byteLen)
+
+    let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: byteLen)
+    defer {
+      buffer.deallocate()
+    }
+
+    CFStringGetBytes(cf, CFRangeMake(0, length),
+                     CFStringBuiltInEncodings.UTF8.rawValue,
+                     0, false, buffer.baseAddress, buffer.count, nil)
+
+    return String(decoding: buffer, as: UTF8.self)
+  }
+}
+
+func CRCopySanitizedPath(_ path: String, _ options: Int) -> String {
+  return fromCFString(Sym.CRCopySanitizedPath(toCFString(path), CFIndex(options)))
+}
+
+// .. Base functionality .......................................................
+
+func CSRetain(_ obj: CSTypeRef) -> CSTypeRef {
+  return Sym.CSRetain(obj)
+}
+
+func CSRelease(_ obj: CSTypeRef) {
+  Sym.CSRelease(obj)
+}
+
+func CSEqual(_ a: CSTypeRef, _ b: CSTypeRef) -> Bool {
+  return Sym.CSEqual(a, b)
+}
+
+func CSIsNull(_ obj: CSTypeRef) -> Bool {
+  return Sym.CSIsNull(obj)
+}
+
+// .. CSSymbolicator ...........................................................
+
+
+struct BinaryRelocationInformation {
+  var base: mach_vm_address_t
+  var extent: mach_vm_address_t
+  var name: String
+}
+
+struct BinaryImageInformation {
+  var base: mach_vm_address_t
+  var extent: mach_vm_address_t
+  var uuid: CFUUIDBytes
+  var arch: CSArchitecture
+  var path: String
+  var relocations: [BinaryRelocationInformation]
+  var flags: UInt32
+}
+
+func CSSymbolicatorCreateWithBinaryImageList(
+  _ imageInfo: [BinaryImageInformation],
+  _ flags: UInt32,
+  _ notificationBlock: CSNotificationBlock?) -> CSSymbolicatorRef {
+
+  // Convert the Swifty types above to suitable input for the C API
+  var pathBuf: [UInt8] = []
+  let imageList = UnsafeMutableBufferPointer<CSBinaryImageInformation>.allocate(capacity: imageInfo.count)
+  defer {
+    imageList.deallocate()
+  }
+
+  var totalRelocations = 0
+  for image in imageInfo {
+    totalRelocations += image.relocations.count
+
+    pathBuf.insert(contentsOf: image.path.utf8, at: pathBuf.count)
+    pathBuf.append(0)
+  }
+
+  let relocationList = UnsafeMutableBufferPointer<CSBinaryRelocationInformation>.allocate(capacity: totalRelocations)
+  defer {
+    relocationList.deallocate()
+  }
+
+  return pathBuf.withUnsafeBufferPointer {
+    $0.withMemoryRebound(to: CChar.self) { pathData in
+      var pathPtr = pathData.baseAddress!
+      var relocationPtr = relocationList.baseAddress!
+
+      for (n, image) in imageInfo.enumerated() {
+        imageList[n].base = image.base
+        imageList[n].extent = image.extent
+        imageList[n].uuid = image.uuid
+        imageList[n].arch = image.arch
+        imageList[n].path = pathPtr
+        imageList[n].relocations = relocationPtr
+        imageList[n].relocationCount = UInt32(image.relocations.count)
+        imageList[n].flags = image.flags
+
+        pathPtr += strlen(pathPtr) + 1
+
+        for relocation in image.relocations {
+          relocationPtr.pointee.base = relocation.base
+          relocationPtr.pointee.extent = relocation.extent
+          withUnsafeMutablePointer(to: &relocationPtr.pointee.name) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 17) { buf in
+              var utf8Iterator = relocation.name.utf8.makeIterator()
+              var ndx = 0
+              while let ch = utf8Iterator.next(), ndx < 16 {
+                buf[ndx] = CChar(bitPattern: ch)
+                ndx += 1
+              }
+              buf[ndx] = 0
+            }
+          }
+
+          relocationPtr += 1
+        }
+      }
+
+      return Sym.CSSymbolicatorCreateWithBinaryImageList(
+        imageList.baseAddress!,
+        UInt32(imageList.count),
+        flags,
+        notificationBlock
+      )
+    }
+  }
+}
+
+func CSSymbolicatorGetSymbolOwnerWithAddressAtTime(
+  _ symbolicator: CSSymbolicatorRef,
+  _ addr: mach_vm_address_t,
+  _ time: CSMachineTime
+) -> CSSymbolOwnerRef {
+  return Sym.CSSymbolicatorGetSymbolOwnerWithAddressAtTime(symbolicator,
+                                                           addr, time)
+}
+
+func CSSymbolicatorForeachSymbolOwnerAtTime(
+  _ symbolicator: CSSymbolicatorRef,
+  _ time: CSMachineTime,
+  _ symbolIterator: (CSSymbolOwnerRef) -> Void
+  ) ->  UInt {
+      return Sym.CSSymbolicatorForeachSymbolOwnerAtTime(symbolicator, time,
+                                                        symbolIterator)
+}
+
+// .. CSSymbolOwner ............................................................
+
+func CSSymbolOwnerGetName(_ sym: CSTypeRef) -> String? {
+  Sym.CSSymbolOwnerGetName(sym)
+    .map(String.init(cString:))
+}
+
+func CSSymbolOwnerGetSymbolWithAddress(
+  _ owner: CSSymbolOwnerRef,
+  _ address: mach_vm_address_t
+) -> CSSymbolRef {
+  return Sym.CSSymbolOwnerGetSymbolWithAddress(owner, address)
+}
+
+func CSSymbolOwnerGetSourceInfoWithAddress(
+  _ owner: CSSymbolOwnerRef,
+  _ address: mach_vm_address_t
+) -> CSSourceInfoRef {
+  return Sym.CSSymbolOwnerGetSourceInfoWithAddress(owner, address)
+}
+
+func CSSymbolOwnerForEachStackFrameAtAddress(
+  _ owner: CSSymbolOwnerRef,
+  _ address: mach_vm_address_t,
+  _ iterator: CSStackFrameIterator
+) -> UInt {
+  return Sym.CSSymbolOwnerForEachStackFrameAtAddress(owner, address, iterator)
+}
+
+func CSSymbolOwnerGetBaseAddress(
+  _ owner: CSSymbolOwnerRef
+) -> mach_vm_address_t {
+  return Sym.CSSymbolOwnerGetBaseAddress(owner)
+}
+
+// .. CSSymbol .................................................................
+
+func CSSymbolGetRange(_ symbol: CSSymbolRef) -> CSRange {
+  return Sym.CSSymbolGetRange(symbol)
+}
+
+func CSSymbolGetName(_ symbol: CSSymbolRef) -> String? {
+  return Sym.CSSymbolGetName(symbol).map{ String(cString: $0) }
+}
+
+func CSSymbolGetMangledName(_ symbol: CSSymbolRef) -> String? {
+  return Sym.CSSymbolGetMangledName(symbol).map{ String(cString: $0) }
+}
+
+// .. CSSourceInfo .............................................................
+
+func CSSourceInfoGetPath(_ sourceInfo: CSSourceInfoRef) -> String? {
+  return Sym.CSSourceInfoGetPath(sourceInfo).map{ String(cString: $0) }
+}
+
+func CSSourceInfoGetLineNumber(_ sourceInfo: CSSourceInfoRef) -> UInt32 {
+  return Sym.CSSourceInfoGetLineNumber(sourceInfo)
+}
+
+func CSSourceInfoGetColumn(_ sourceInfo: CSSourceInfoRef) -> UInt32 {
+  return Sym.CSSourceInfoGetColumn(sourceInfo)
+}
+
+#endif // os(Darwin)

--- a/stdlib/public/Backtracing/CoreSymbolication.swift
+++ b/stdlib/public/Backtracing/CoreSymbolication.swift
@@ -117,8 +117,8 @@ private enum Sym {
 // CFString.  As a result, we need to do the dance manually.
 
 private func toCFString(_ s: String) -> CFString! {
-  let bytes = Array<UInt8>(s.utf8)
-  return bytes.withUnsafeBufferPointer{
+  var s = s
+  return s.withUTF8 {
     return CFStringCreateWithBytes(nil,
                                    $0.baseAddress,
                                    $0.count,
@@ -135,10 +135,8 @@ private func fromCFString(_ cf: CFString) -> String {
 
   if let ptr = CFStringGetCStringPtr(cf,
                                      CFStringBuiltInEncodings.ASCII.rawValue) {
-    return ptr.withMemoryRebound(to: UInt8.self, capacity: length) {
-      return String(decoding: UnsafeBufferPointer(start: $0, count: length),
-                    as: UTF8.self)
-    }
+    return String(decoding: UnsafeRawBufferPointer(start: ptr, count: length),
+                  as: UTF8.self)
   } else {
     var byteLen = CFIndex(0)
 

--- a/stdlib/public/Backtracing/FramePointerUnwinder.swift
+++ b/stdlib/public/Backtracing/FramePointerUnwinder.swift
@@ -1,0 +1,152 @@
+//===--- FramePointerUnwinder.swift ---------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Unwind the stack by chasing the frame pointer.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+// @available(SwiftStdlib 5.1, *)
+@_silgen_name("swift_task_getCurrent")
+func _getCurrentAsyncTask() -> UnsafeRawPointer?
+
+@_spi(Unwinders)
+public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, IteratorProtocol {
+  public typealias Context = C
+  public typealias MemoryReader = M
+  public typealias Address = MemoryReader.Address
+
+  var pc: Address
+  var fp: Address
+  var asyncContext: Address
+  var first: Bool
+  var isAsync: Bool
+
+  var reader: MemoryReader
+
+  public init(context: Context, memoryReader: MemoryReader) {
+    pc = Address(context.programCounter)
+    fp = Address(context.framePointer)
+    first = true
+    isAsync = false
+    asyncContext = 0
+    reader = memoryReader
+  }
+
+  private func isAsyncFrame(_ storedFp: Address) -> Bool {
+    #if (os(macOS) || os(iOS) || os(watchOS)) && (arch(arm64) || arch(arm64_32) || arch(x86_64))
+    // On Darwin, we borrow a bit of the frame pointer to indicate async
+    // stack frames
+    return (storedFp & (1 << 60)) != 0 && _getCurrentAsyncTask() != nil
+    #else
+    return false
+    #endif
+  }
+
+  private func stripPtrAuth(_ address: Address) -> Address {
+    return Address(Context.stripPtrAuth(address: Context.Address(address)))
+  }
+
+  private mutating func fetchAsyncContext() -> Bool {
+    let strippedFp = stripPtrAuth(fp)
+
+    do {
+      asyncContext = try reader.fetch(from: Address(strippedFp - 8),
+                                      as: Address.self)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  public mutating func next() -> Backtrace.Frame? {
+    if first {
+      first = false
+      pc = stripPtrAuth(pc)
+      return .programCounter(Backtrace.Address(pc))
+    }
+
+    if !isAsync {
+      // Try to read the next fp/pc pair
+      var next: Address = 0
+      let strippedFp = stripPtrAuth(fp)
+
+      if strippedFp == 0
+           || !Context.isAlignedForStack(framePointer:
+                                           Context.Address(strippedFp)) {
+        return nil
+      }
+
+      do {
+        pc = stripPtrAuth(try reader.fetch(from:
+                 strippedFp + Address(MemoryLayout<Address>.size),
+                 as: Address.self))
+        next = try reader.fetch(from: Address(strippedFp), as: Address.self)
+      } catch {
+        return nil
+      }
+
+      if next <= fp {
+        return nil
+      }
+
+      if !isAsyncFrame(next) {
+        fp = next
+        return .returnAddress(Backtrace.Address(pc))
+      }
+
+      isAsync = true
+      if !fetchAsyncContext() {
+        return nil
+      }
+    }
+
+    // If we get here, we're in async mode
+
+    var next: Address = 0
+    let strippedCtx = stripPtrAuth(asyncContext)
+
+    if strippedCtx == 0 {
+      return nil
+    }
+
+    #if arch(arm64_32)
+
+    // On arm64_32, the two pointers at the start of the context are 32-bit,
+    // although the stack layout is identical to vanilla arm64
+    do {
+      var next32 = try reader.fetch(from: strippedCtx, as: UInt32.self)
+      var pc32 = try reader.fetch(from: strippedCtx + 4, as: UInt32.self)
+
+      next = Address(next32)
+      pc = stripPtrAuth(Address(pc32))
+    } catch {
+      return nil
+    }
+    #else
+
+    // Otherwise it's two 64-bit words
+    do {
+      next = try reader.fetch(from: strippedCtx, as: Address.self)
+      pc = stripPtrAuth(try reader.fetch(from: strippedCtx + 8, as: Address.self))
+    } catch {
+      return nil
+    }
+
+    #endif
+
+    asyncContext = next
+
+    return .asyncResumePoint(Backtrace.Address(pc))
+  }
+}

--- a/stdlib/public/Backtracing/MemoryReader.swift
+++ b/stdlib/public/Backtracing/MemoryReader.swift
@@ -1,0 +1,118 @@
+//===--- MemoryReader.swift -----------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Provides the ability to read memory, both in the current process and
+//  remotely.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@_implementationOnly import _SwiftBacktracingShims
+
+@_spi(MemoryReaders) public protocol MemoryReader {
+  associatedtype Address: FixedWidthInteger
+
+  func fetch<T>(from address: Address,
+                into buffer: UnsafeMutableBufferPointer<T>) throws
+
+  func fetch<T>(from addr: Address,
+                into pointer: UnsafeMutablePointer<T>) throws
+
+  func fetch<T>(from addr: Address, count: Int, as: T.Type) throws -> [T]
+
+  func fetch<T>(from addr: Address, as: T.Type) throws -> T
+}
+
+extension MemoryReader {
+
+  public func fetch<T>(from addr: Address,
+                       into pointer: UnsafeMutablePointer<T>) throws {
+    try fetch(from: addr,
+              into: UnsafeMutableBufferPointer(start: pointer, count: 1))
+  }
+
+  public func fetch<T>(from addr: Address, count: Int, as: T.Type) throws -> [T] {
+    let array = try Array<T>(unsafeUninitializedCapacity: count){
+      buffer, initializedCount in
+
+      try fetch(from: addr, into: buffer)
+
+      initializedCount = count
+    }
+
+    return array
+  }
+
+  public func fetch<T>(from addr: Address, as: T.Type) throws -> T {
+    return try withUnsafeTemporaryAllocation(of: T.self, capacity: 1) { buf in
+      try fetch(from: addr, into: buf)
+      return buf[0]
+    }
+  }
+
+}
+
+@_spi(MemoryReaders) public struct UnsafeLocalMemoryReader: MemoryReader {
+  public typealias Address = UInt
+
+  public func fetch<T>(from address: Address,
+                       into buffer: UnsafeMutableBufferPointer<T>) throws {
+    buffer.baseAddress!.update(from: UnsafePointer<T>(bitPattern: address)!,
+                               count: buffer.count)
+  }
+}
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@_implementationOnly import Darwin.Mach
+
+@_spi(MemoryReaders) public struct MachError: Error {
+  var result: kern_return_t
+}
+
+@_spi(MemoryReaders) public struct RemoteMemoryReader: MemoryReader {
+  public typealias Address = UInt64
+
+  private var task: task_t
+
+  // Sadly we can't expose the type of this argument
+  public init(task: Any) {
+    self.task = task as! task_t
+  }
+
+  public func fetch<T>(from address: Address,
+                       into buffer: UnsafeMutableBufferPointer<T>) throws {
+    let size = mach_vm_size_t(MemoryLayout<T>.stride * buffer.count)
+    var sizeOut = mach_vm_size_t(0)
+    let kr = mach_vm_read_overwrite(task,
+                                    mach_vm_address_t(address),
+                                    mach_vm_size_t(size),
+                                    unsafeBitCast(buffer.baseAddress,
+                                                  to: mach_vm_address_t.self),
+                                    &sizeOut)
+
+    if kr != KERN_SUCCESS {
+      throw MachError(result: kr)
+    }
+  }
+}
+
+@_spi(MemoryReaders) public struct LocalMemoryReader: MemoryReader {
+  public typealias Address = UInt64
+
+  public func fetch<T>(from address: Address,
+                       into buffer: UnsafeMutableBufferPointer<T>) throws {
+    let reader = RemoteMemoryReader(task: mach_task_self_)
+    return try reader.fetch(from: address, into: buffer)
+  }
+}
+#endif

--- a/stdlib/public/Backtracing/Registers.swift
+++ b/stdlib/public/Backtracing/Registers.swift
@@ -1,0 +1,586 @@
+//===--- Registers.swift - Dwarf register mapping -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Holds enums that define DWARF register mappings for the architectures we
+// care about.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+// .. x86-64 .................................................................
+
+// https://gitlab.com/x86-psABIs/x86-64-ABI
+@_spi(Registers) public enum X86_64Register: Int, Strideable, Comparable {
+
+  public func advanced(by n: Int) -> X86_64Register {
+    return X86_64Register(rawValue: self.rawValue + n)!
+  }
+
+  public func distance(to other: X86_64Register) -> Int {
+    return other.rawValue - self.rawValue
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+
+case rax = 0
+case rdx = 1
+case rcx = 2
+case rbx = 3
+case rsi = 4
+case rdi = 5
+case rbp = 6
+case rsp = 7
+case r8  = 8
+case r9  = 9
+case r10 = 10
+case r11 = 11
+case r12 = 12
+case r13 = 13
+case r14 = 14
+case r15 = 15
+case ra = 16
+case xmm0 = 17
+case xmm1 = 18
+case xmm2 = 19
+case xmm3 = 20
+case xmm4 = 21
+case xmm5 = 22
+case xmm6 = 23
+case xmm7 = 24
+case xmm8 = 25
+case xmm9 = 26
+case xmm10 = 27
+case xmm11 = 28
+case xmm12 = 29
+case xmm13 = 30
+case xmm14 = 31
+case xmm15 = 32
+case st0 = 33
+case st1 = 34
+case st2 = 35
+case st3 = 36
+case st4 = 37
+case st5 = 38
+case st6 = 39
+case st7 = 40
+case mm0 = 41
+case mm1 = 42
+case mm2 = 43
+case mm3 = 44
+case mm4 = 45
+case mm5 = 46
+case mm6 = 47
+case mm7 = 48
+case rflags = 49
+case es = 50
+case cs = 51
+case ss = 52
+case ds = 53
+case fs = 54
+case gs = 55
+  // 56-57 are reserved
+case fs_base = 58
+case gs_base = 59
+  // 60-61 are reserved
+case tr = 62
+case ldtr = 63
+case mxcsr = 64
+case fcw = 65
+case fsw = 66
+case xmm16 = 67
+case xmm17 = 68
+case xmm18 = 69
+case xmm19 = 70
+case xmm20 = 71
+case xmm21 = 72
+case xmm22 = 73
+case xmm23 = 74
+case xmm24 = 75
+case xmm25 = 76
+case xmm26 = 77
+case xmm27 = 78
+case xmm28 = 79
+case xmm29 = 80
+case xmm30 = 81
+case xmm31 = 82
+  // 83-117 are reserved
+case k0 = 118
+case k1 = 119
+case k2 = 120
+case k3 = 121
+case k4 = 122
+case k5 = 123
+case k6 = 124
+case k7 = 125
+  // 126-129 are reserved
+}
+
+// .. i386 ...................................................................
+
+// https://gitlab.com/x86-psABIs/i386-ABI
+@_spi(Registers) public enum I386Register: Int, Strideable, Comparable {
+
+  public func advanced(by n: Int) -> I386Register {
+    return I386Register(rawValue: self.rawValue + n)!
+  }
+
+  public func distance(to other: I386Register) -> Int {
+    return other.rawValue - self.rawValue
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+
+case eax = 0
+case ecx = 1
+case edx = 2
+case ebx = 3
+case esp = 4
+case ebp = 5
+case esi = 6
+case edi = 7
+case ra = 8
+case eflags = 9
+  // 10 is reserved
+case st0 = 11
+case st1 = 12
+case st2 = 13
+case st3 = 14
+case st4 = 15
+case st5 = 16
+case st6 = 17
+case st7 = 18
+  // 19-20 are reserved
+case xmm0 = 21
+case xmm1 = 22
+case xmm2 = 23
+case xmm3 = 24
+case xmm4 = 25
+case xmm5 = 26
+case xmm6 = 27
+case xmm7 = 28
+case mm0 = 29
+case mm1 = 30
+case mm2 = 31
+case mm3 = 32
+case mm4 = 33
+case mm5 = 34
+case mm6 = 35
+case mm7 = 36
+  // 36-38 are reserved
+case mxcsr = 39
+case es = 40
+case cs = 41
+case ss = 42
+case ds = 43
+case fs = 44
+case gs = 45
+  // 46-47 are reserved
+case tr = 48
+case ldtr = 49
+  // 50-92 are reserved
+case fs_base = 93
+case gs_base = 94
+}
+
+// .. arm64 ..................................................................
+
+// https://github.com/ARM-software/abi-aa/tree/main/aadwarf64
+@_spi(Registers) public enum ARM64Register: Int, Strideable, Comparable {
+
+  public func advanced(by n: Int) -> ARM64Register {
+    return ARM64Register(rawValue: self.rawValue + n)!
+  }
+
+  public func distance(to other: ARM64Register) -> Int {
+    return other.rawValue - self.rawValue
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+
+case x0 = 0
+case x1 = 1
+case x2 = 2
+case x3 = 3
+case x4 = 4
+case x5 = 5
+case x6 = 6
+case x7 = 7
+case x8 = 8
+case x9 = 9
+case x10 = 10
+case x11 = 11
+case x12 = 12
+case x13 = 13
+case x14 = 14
+case x15 = 15
+case x16 = 16
+case x17 = 17
+case x18 = 18
+case x19 = 19
+case x20 = 20
+case x21 = 21
+case x22 = 22
+case x23 = 23
+case x24 = 24
+case x25 = 25
+case x26 = 26
+case x27 = 27
+case x28 = 28
+case x29 = 29 // fp
+case x30 = 30 // lr
+case sp = 31  // x31
+case pc = 32
+case elr_mode = 33
+case ra_sign_state = 34
+case tpidrro_el0 = 35
+case tpidr_el0 = 36
+case tpidr_el1 = 37
+case tpidr_el2 = 38
+case tpidr_el3 = 39
+  // 40-45 are reserved
+case vg = 46
+case ffr = 47
+case p0 = 48
+case p1 = 49
+case p2 = 50
+case p3 = 51
+case p4 = 52
+case p5 = 53
+case p6 = 54
+case p7 = 55
+case p8 = 56
+case p9 = 57
+case p10 = 58
+case p11 = 59
+case p12 = 60
+case p13 = 61
+case p14 = 62
+case p15 = 63
+case v0 = 64
+case v1 = 65
+case v2 = 66
+case v3 = 67
+case v4 = 68
+case v5 = 69
+case v6 = 70
+case v7 = 71
+case v8 = 72
+case v9 = 73
+case v10 = 74
+case v11 = 75
+case v12 = 76
+case v13 = 77
+case v14 = 78
+case v15 = 79
+case v16 = 80
+case v17 = 81
+case v18 = 82
+case v19 = 83
+case v20 = 84
+case v21 = 85
+case v22 = 86
+case v23 = 87
+case v24 = 88
+case v25 = 89
+case v26 = 90
+case v27 = 91
+case v28 = 92
+case v29 = 93
+case v30 = 94
+case v31 = 95
+case z0 = 96
+case z1 = 97
+case z2 = 98
+case z3 = 99
+case z4 = 100
+case z5 = 101
+case z6 = 102
+case z7 = 103
+case z8 = 104
+case z9 = 105
+case z10 = 106
+case z11 = 107
+case z12 = 108
+case z13 = 109
+case z14 = 110
+case z15 = 111
+case z16 = 112
+case z17 = 113
+case z18 = 114
+case z19 = 115
+case z20 = 116
+case z21 = 117
+case z22 = 118
+case z23 = 119
+case z24 = 120
+case z25 = 121
+case z26 = 122
+case z27 = 123
+case z28 = 124
+case z29 = 125
+case z30 = 126
+case z31 = 127
+}
+
+// .. arm ....................................................................
+
+// https://github.com/ARM-software/abi-aa/tree/main/aadwarf32
+@_spi(Registers) public enum ARMRegister: Int, Strideable, Comparable {
+
+  public func advanced(by n: Int) -> ARMRegister {
+    return ARMRegister(rawValue: self.rawValue + n)!
+  }
+
+  public func distance(to other: ARMRegister) -> Int {
+    return other.rawValue - self.rawValue
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+
+case r0 = 0
+case r1 = 1
+case r2 = 2
+case r3 = 3
+case r4 = 4
+case r5 = 5
+case r6 = 6
+case r7 = 7
+case r8 = 8
+case r9 = 9
+case r10 = 10
+case r11 = 11 // fp
+case r12 = 12 // ip - scratch register (NOT "instruction pointer")
+case r13 = 13 // sp
+case r14 = 14 // lr
+case r15 = 15 // pc
+
+  // Obsolescent, overlapping mappings for FPA and VFP
+case old_f0_s0 = 16
+case old_f1_s1 = 17
+case old_f2_s2 = 18
+case old_f3_s3 = 19
+case old_f4_s4 = 20
+case old_f5_s5 = 21
+case old_f6_s6 = 22
+case old_f7_s7 = 23
+case old_s8 = 24
+case old_s9 = 25
+case old_s10 = 26
+case old_s11 = 27
+case old_s12 = 28
+case old_s13 = 29
+case old_s14 = 30
+case old_s15 = 31
+case old_s16 = 32
+case old_s17 = 33
+case old_s18 = 34
+case old_s19 = 35
+case old_s20 = 36
+case old_s21 = 37
+case old_s22 = 38
+case old_s23 = 39
+case old_s24 = 40
+case old_s25 = 41
+case old_s26 = 42
+case old_s27 = 43
+case old_s28 = 44
+case old_s29 = 45
+case old_s30 = 46
+case old_s31 = 47
+
+  // Legacy VFPv2
+case s0 = 64
+case s1 = 65
+case s2 = 66
+case s3 = 67
+case s4 = 68
+case s5 = 69
+case s6 = 70
+case s7 = 71
+case s8 = 72
+case s9 = 73
+case s10 = 74
+case s11 = 75
+case s12 = 76
+case s13 = 77
+case s14 = 78
+case s15 = 79
+case s16 = 80
+case s17 = 81
+case s18 = 82
+case s19 = 83
+case s20 = 84
+case s21 = 85
+case s22 = 86
+case s23 = 87
+case s24 = 88
+case s25 = 89
+case s26 = 90
+case s27 = 91
+case s28 = 92
+case s29 = 93
+case s30 = 94
+case s31 = 95
+
+  // Obsolescent FPA registers
+case f0 = 96
+case f1 = 97
+case f2 = 98
+case f3 = 99
+case f4 = 100
+case f5 = 101
+case f6 = 102
+case f7 = 103
+
+  // Intel wireless MMX GPRs / XScale accumulators
+case wcgr0_acc0 = 104
+case wcgr1_acc1 = 105
+case wcgr2_acc2 = 106
+case wcgr3_acc3 = 107
+case wcgr4_acc4 = 108
+case wcgr5_acc5 = 109
+case wcgr6_acc6 = 110
+case wcgr7_acc7 = 111
+
+  // Intel wireless MMX data registers
+case wr0 = 112
+case wr1 = 113
+case wr2 = 114
+case wr3 = 115
+case wr4 = 116
+case wr5 = 117
+case wr6 = 118
+case wr7 = 119
+case wr8 = 120
+case wr9 = 121
+case wr10 = 122
+case wr11 = 123
+case wr12 = 124
+case wr13 = 125
+case wr14 = 126
+case wr15 = 127
+
+case spsr = 128
+case spsr_fiq = 129
+case spsr_irq = 130
+case spsr_abt = 131
+case spsr_und = 132
+case spsr_svc = 133
+
+  // 134-142 are reserved
+
+case ra_auth_code = 143
+
+case r8_usr = 144
+case r9_usr = 145
+case r10_usr = 146
+case r11_usr = 147
+case r12_usr = 148
+case r13_usr = 149
+case r14_usr = 150
+
+case r8_fiq = 151
+case r9_fiq = 152
+case r10_fiq = 153
+case r11_fiq = 154
+case r12_fiq = 155
+case r13_fiq = 156
+case r14_fiq = 157
+
+case r13_irq = 158
+case r14_irq = 159
+
+case r13_abt = 160
+case r14_abt = 161
+
+case r13_und = 162
+case r14_und = 163
+
+case r13_svc = 164
+case r14_svc = 165
+
+  // 166-191 are reserved
+
+  // Intel wqireless MMX control register
+case wc0 = 192
+case wc1 = 193
+case wc2 = 194
+case wc3 = 195
+case wc4 = 196
+case wc5 = 197
+case wc6 = 198
+case wc7 = 199
+
+  // 200-255 are reserved
+
+case d0 = 256
+case d1 = 257
+case d2 = 258
+case d3 = 259
+case d4 = 260
+case d5 = 261
+case d6 = 262
+case d7 = 263
+case d8 = 264
+case d9 = 265
+case d10 = 266
+case d11 = 267
+case d12 = 268
+case d13 = 269
+case d14 = 270
+case d15 = 271
+case d16 = 272
+case d17 = 273
+case d18 = 274
+case d19 = 275
+case d20 = 276
+case d21 = 277
+case d22 = 278
+case d23 = 279
+case d24 = 280
+case d25 = 281
+case d26 = 282
+case d27 = 283
+case d28 = 284
+case d29 = 285
+case d30 = 286
+case d31 = 287
+
+  // 288-319 are reserved
+
+case tpidruro = 320
+case tpidrurw = 321
+case tpidpr = 322
+case htpidpr = 323
+
+  // 324-8191 are reserved
+  // 8192-16383 are for vendor co-processors
+}
+
+#if arch(x86_64)
+@_spi(Registers) public typealias HostRegister = X86_64Register
+#elseif arch(i386)
+@_spi(Registers) public typealias HostRegister = I386Register
+#elseif arch(arm64) || arch(arm64_32)
+@_spi(Registers) public typealias HostRegister = ARM64Register
+#elseif arch(arm)
+@_spi(Registers) public typealias HostRegister = ARMRegister
+#endif

--- a/stdlib/public/Backtracing/SymbolicatedBacktrace.swift
+++ b/stdlib/public/Backtracing/SymbolicatedBacktrace.swift
@@ -1,0 +1,464 @@
+//===--- Backtrace.swift --------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines the `SymbolicatedBacktrace` struct that represents a captured
+//  backtrace with symbols.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@_implementationOnly import _SwiftBacktracingShims
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@_implementationOnly import CoreFoundation
+#endif
+
+@_silgen_name("_swift_isThunkFunction")
+func _swift_isThunkFunction(
+  _ rawName: UnsafePointer<CChar>?
+) -> CBool
+
+/// A symbolicated backtrace
+public struct SymbolicatedBacktrace: CustomStringConvertible {
+  /// The `Backtrace` from which this was constructed
+  public var backtrace: Backtrace
+
+  /// Represents a location in source code.
+  ///
+  /// The information in this structure comes from compiler-generated
+  /// debug information and may not correspond to the current state of
+  /// the filesystem --- it might even hold a path that only works
+  /// from an entirely different machine.
+  public struct SourceLocation: CustomStringConvertible, Sendable, Hashable {
+    /// The path of the source file.
+    public var path: String
+
+    /// The line number.
+    public var line: Int
+
+    /// The column number.
+    public var column: Int
+
+    /// Provide a textual description.
+    public var description: String {
+      if column > 0 && line > 0 {
+        return "\(path):\(line):\(column)"
+      } else if line > 0 {
+        return "\(path):\(line)"
+      } else {
+        return path
+      }
+    }
+  }
+
+  /// Represents an individual frame in the backtrace.
+  public struct Frame: CustomStringConvertible {
+    /// The captured frame from the `Backtrace`.
+    public var captured: Backtrace.Frame
+
+    /// The result of doing a symbol lookup for this frame.
+    public var symbol: Symbol?
+
+    /// If `true`, then this frame was inlined
+    public var inlined: Bool = false
+
+    /// `true` if this frame represents a Swift runtime failure.
+    public var isSwiftRuntimeFailure: Bool {
+      symbol?.isSwiftRuntimeFailure ?? false
+    }
+
+    /// `true` if this frame represents a Swift thunk function.
+    public var isSwiftThunk: Bool {
+      symbol?.isSwiftThunk ?? false
+    }
+
+    /// `true` if this frame is a system frame.
+    public var isSystem: Bool {
+      symbol?.isSystemFunction ?? false
+    }
+
+    /// A textual description of this frame.
+    public var description: String {
+      if let symbol = symbol {
+        let isInlined = inlined ? " [inlined]" : ""
+        let isThunk = isSwiftThunk ? " [thunk]" : ""
+        return "\(captured)\(isInlined)\(isThunk) \(symbol)"
+      } else {
+        return captured.description
+      }
+    }
+  }
+
+  /// Represents a symbol we've located
+  public class Symbol: CustomStringConvertible {
+    /// The index of the image in which the symbol for this address is located.
+    public var imageIndex: Int
+
+    /// The name of the image in which the symbol for this address is located.
+    public var imageName: String
+
+    /// The raw symbol name, before demangling.
+    public var rawName: String
+
+    /// The demangled symbol name.
+    public lazy var name: String = demangleRawName()
+
+    /// The offset from the symbol.
+    public var offset: Int
+
+    /// The source location, if available.
+    public var sourceLocation: SourceLocation?
+
+    /// True if this symbol represents a Swift runtime failure.
+    public var isSwiftRuntimeFailure: Bool {
+      guard let sourceLocation = sourceLocation else {
+        return false
+      }
+
+      let symName: Substring
+      if rawName.hasPrefix("_") {
+        symName = rawName.dropFirst()
+      } else {
+        symName = rawName.dropFirst(0)
+      }
+
+      return symName.hasPrefix("Swift runtime failure: ")
+        && sourceLocation.line == 0
+        && sourceLocation.column == 0
+        && sourceLocation.path.hasSuffix("<compiler-generated>")
+    }
+
+    /// True if this symbol is a Swift thunk function.
+    public var isSwiftThunk: Bool {
+      return _swift_isThunkFunction(rawName)
+    }
+
+    /// True if this symbol represents a system function.
+    ///
+    /// For instance, the `start` function from `dyld` on macOS is a system
+    /// function, and we don't need to display it under normal circumstances.
+    public var isSystemFunction: Bool {
+      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+      if rawName == "start" && imageName == "dyld" {
+        return true
+      }
+      if let location = sourceLocation,
+         location.line == 0 && location.column == 0 {
+        return true
+      }
+      if rawName.hasSuffix("5$mainyyFZ") {
+        return true
+      }
+      #endif
+      return false
+    }
+
+    /// Construct a new Symbol.
+    public init(imageIndex: Int, imageName: String,
+                rawName: String, offset: Int, sourceLocation: SourceLocation?) {
+      self.imageIndex = imageIndex
+      self.imageName = imageName
+      self.rawName = rawName
+      self.offset = offset
+      self.sourceLocation = sourceLocation
+    }
+
+    /// Demangle the raw name, if possible.
+    private func demangleRawName() -> String {
+      // We don't actually need this function on macOS because we're using
+      // CoreSymbolication, which demangles the name when it does the lookup
+      // anyway.  We will need it for Linux and Windows though.
+      return rawName
+    }
+
+    /// A textual description of this symbol.
+    public var description: String {
+      let symPlusOffset: String
+
+      if offset > 0 {
+        symPlusOffset = "\(name) + \(offset)"
+      } else if offset < 0 {
+        symPlusOffset = "\(name) - \(-offset)"
+      } else {
+        symPlusOffset = name
+      }
+
+      let location: String
+      if let sourceLocation = sourceLocation {
+        location = " at \(sourceLocation)"
+      } else {
+        location = ""
+      }
+
+      return "[\(imageIndex)] \(imageName) \(symPlusOffset)\(location)"
+    }
+  }
+
+  /// A list of captured frame information.
+  public var frames: [Frame]
+
+  /// A list of images found in the process.
+  public var images: [Backtrace.Image]
+
+  /// Shared cache information.
+  public var sharedCacheInfo: Backtrace.SharedCacheInfo
+
+  /// True if this backtrace is a Swift runtime failure.
+  public var isSwiftRuntimeFailure: Bool {
+    guard let frame = frames.first else { return false }
+    return frame.isSwiftRuntimeFailure
+  }
+
+  /// If this backtrace is a Swift runtime failure, return the description.
+  public var swiftRuntimeFailure: String? {
+    guard let frame = frames.first else { return nil }
+    if !frame.isSwiftRuntimeFailure { return nil }
+
+    let symbolName = frame.symbol!.rawName
+    if symbolName.hasPrefix("_") {
+      return String(symbolName.dropFirst())
+    }
+    return symbolName
+  }
+
+  /// Construct a SymbolicatedBacktrace from a backtrace and a list of images.
+  private init(backtrace: Backtrace, images: [Backtrace.Image],
+               sharedCacheInfo: Backtrace.SharedCacheInfo,
+               frames: [Frame]) {
+    self.backtrace = backtrace
+    self.images = images
+    self.sharedCacheInfo = sharedCacheInfo
+    self.frames = frames
+  }
+
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  /// Convert a build ID to a CFUUIDBytes.
+  private static func uuidBytesFromBuildID(_ buildID: [UInt8]) -> CFUUIDBytes {
+    var result = CFUUIDBytes()
+    withUnsafeMutablePointer(to: &result) {
+      $0.withMemoryRebound(to: UInt8.self,
+                           capacity: MemoryLayout<CFUUIDBytes>.size) {
+        let bp = UnsafeMutableBufferPointer(start: $0,
+                                            count: MemoryLayout<CFUUIDBytes>.size)
+        _ = bp.initialize(from: buildID)
+      }
+    }
+    return result
+  }
+
+  /// Create a symbolicator.
+  private static func withSymbolicator<T>(images: [Backtrace.Image],
+                                          sharedCacheInfo: Backtrace.SharedCacheInfo,
+                                          fn: (CSSymbolicatorRef) throws -> T) rethrows -> T {
+    let binaryImageList = images.map{ image in
+      BinaryImageInformation(
+        base: image.baseAddress,
+        extent: image.endOfText,
+        uuid: uuidBytesFromBuildID(image.buildID!),
+        arch: HostContext.coreSymbolicationArchitecture,
+        path: image.path,
+        relocations: [
+          BinaryRelocationInformation(
+            base: image.baseAddress,
+            extent: image.endOfText,
+            name: "__TEXT"
+          )
+        ],
+        flags: 0
+      )
+    }
+
+    let symbolicator = CSSymbolicatorCreateWithBinaryImageList(
+      binaryImageList, 0, nil
+    )
+
+    defer { CSRelease(symbolicator) }
+
+    return try fn(symbolicator)
+  }
+
+  /// Generate a frame from a symbol and source info pair
+  private static func buildFrame(from capturedFrame: Backtrace.Frame,
+                                 with owner: CSSymbolOwnerRef,
+                                 isInline: Bool,
+                                 symbol: CSSymbolRef,
+                                 sourceInfo: CSSourceInfoRef,
+                                 images: [Backtrace.Image]) -> Frame {
+    if CSIsNull(symbol) {
+      return Frame(captured: capturedFrame, symbol: nil)
+    }
+
+    let address = capturedFrame.originalProgramCounter
+    let rawName = CSSymbolGetMangledName(symbol) ?? "<unknown>"
+    let name = CSSymbolGetName(symbol) ?? rawName
+    let range = CSSymbolGetRange(symbol)
+
+    let location: SourceLocation?
+
+    if !CSIsNull(sourceInfo) {
+      let path = CSSourceInfoGetPath(sourceInfo) ?? "<unknown>"
+      let line = CSSourceInfoGetLineNumber(sourceInfo)
+      let column = CSSourceInfoGetColumn(sourceInfo)
+
+      location = SourceLocation(
+        path: path,
+        line: Int(line),
+        column: Int(column)
+      )
+    } else {
+      location = nil
+    }
+
+    let imageBase = CSSymbolOwnerGetBaseAddress(owner)
+    var imageIndex = -1
+    var imageName = ""
+    for (ndx, image) in images.enumerated() {
+      if image.baseAddress == imageBase {
+        imageIndex = ndx
+        imageName = image.name
+        break
+      }
+    }
+
+    let theSymbol = Symbol(imageIndex: imageIndex,
+                           imageName: imageName,
+                           rawName: rawName,
+                           offset: Int(address - range.location),
+                           sourceLocation: location)
+    theSymbol.name = name
+
+    return Frame(captured: capturedFrame, symbol: theSymbol, inlined: isInline)
+  }
+  #endif
+
+  /// Actually symbolicate.
+  internal static func symbolicate(backtrace: Backtrace,
+                                   images: [Backtrace.Image]?,
+                                   sharedCacheInfo: Backtrace.SharedCacheInfo?,
+                                   showInlineFrames: Bool)
+    -> SymbolicatedBacktrace? {
+
+    let theImages: [Backtrace.Image]
+    if let images = images {
+      theImages = images
+    } else if let images = backtrace.images {
+      theImages = images
+    } else {
+      theImages = Backtrace.captureImages()
+    }
+
+    let theCacheInfo: Backtrace.SharedCacheInfo
+    if let sharedCacheInfo = sharedCacheInfo {
+      theCacheInfo = sharedCacheInfo
+    } else if let sharedCacheInfo = backtrace.sharedCacheInfo {
+      theCacheInfo = sharedCacheInfo
+    } else {
+      theCacheInfo = Backtrace.captureSharedCacheInfo()
+    }
+
+    var frames: [Frame] = []
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    withSymbolicator(images: theImages,
+                     sharedCacheInfo: theCacheInfo) { symbolicator in
+      for frame in backtrace.frames {
+        switch frame {
+          case .omittedFrames(_), .truncated:
+            frames.append(Frame(captured: frame, symbol: nil))
+          default:
+            let address = frame.adjustedProgramCounter
+            let owner
+              = CSSymbolicatorGetSymbolOwnerWithAddressAtTime(symbolicator,
+                                                              address,
+                                                              kCSBeginningOfTime)
+
+            if CSIsNull(owner) {
+              frames.append(Frame(captured: frame, symbol: nil))
+            } else if showInlineFrames {
+              // These present in *reverse* order (i.e. the real one first,
+              // then the inlined frames from callee to caller).
+              let pos = frames.count
+              var first = true
+
+              _ = CSSymbolOwnerForEachStackFrameAtAddress(owner, address){
+                symbol, sourceInfo in
+
+                frames.insert(buildFrame(from: frame,
+                                         with: owner,
+                                         isInline: !first,
+                                         symbol: symbol,
+                                         sourceInfo: sourceInfo,
+                                         images: theImages),
+                              at: pos)
+
+                first = false
+              }
+            } else {
+              let symbol = CSSymbolOwnerGetSymbolWithAddress(owner, address)
+              let sourceInfo = CSSymbolOwnerGetSourceInfoWithAddress(owner,
+                                                                     address)
+
+              frames.append(buildFrame(from: frame,
+                                       with: owner,
+                                       isInline: false,
+                                       symbol: symbol,
+                                       sourceInfo: sourceInfo,
+                                       images: theImages))
+            }
+        }
+      }
+    }
+    #else
+    frames = backtrace.frames.map{ Frame(captured: $0, symbol: nil) }
+    #endif
+
+    return SymbolicatedBacktrace(backtrace: backtrace,
+                                 images: theImages,
+                                 sharedCacheInfo: theCacheInfo,
+                                 frames: frames)
+  }
+
+  /// Provide a textual version of the backtrace.
+  public var description: String {
+    var lines: [String] = []
+
+    var n = 0
+    for frame in frames {
+      lines.append("\(n)\t\(frame)")
+      switch frame.captured {
+        case let .omittedFrames(count):
+          n += count
+        default:
+          n += 1
+      }
+    }
+
+    lines.append("")
+    lines.append("Images:")
+    lines.append("")
+    for (n, image) in images.enumerated() {
+      lines.append("\(n)\t\(image)")
+    }
+
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    lines.append("")
+    lines.append("Shared Cache:")
+    lines.append("")
+    lines.append("    UUID: \(hex(sharedCacheInfo.uuid))")
+    lines.append("    Base: \(hex(sharedCacheInfo.baseAddress))")
+    lines.append("  Active: \(!sharedCacheInfo.noCache)")
+    #endif
+
+    return lines.joined(separator: "\n")
+  }
+}

--- a/stdlib/public/Backtracing/SymbolicatedBacktrace.swift
+++ b/stdlib/public/Backtracing/SymbolicatedBacktrace.swift
@@ -211,7 +211,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
   public var images: [Backtrace.Image]
 
   /// Shared cache information.
-  public var sharedCacheInfo: Backtrace.SharedCacheInfo
+  public var sharedCacheInfo: Backtrace.SharedCacheInfo?
 
   /// True if this backtrace is a Swift runtime failure.
   public var isSwiftRuntimeFailure: Bool {
@@ -233,7 +233,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
 
   /// Construct a SymbolicatedBacktrace from a backtrace and a list of images.
   private init(backtrace: Backtrace, images: [Backtrace.Image],
-               sharedCacheInfo: Backtrace.SharedCacheInfo,
+               sharedCacheInfo: Backtrace.SharedCacheInfo?,
                frames: [Frame]) {
     self.backtrace = backtrace
     self.images = images
@@ -258,7 +258,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
 
   /// Create a symbolicator.
   private static func withSymbolicator<T>(images: [Backtrace.Image],
-                                          sharedCacheInfo: Backtrace.SharedCacheInfo,
+                                          sharedCacheInfo: Backtrace.SharedCacheInfo?,
                                           fn: (CSSymbolicatorRef) throws -> T) rethrows -> T {
     let binaryImageList = images.map{ image in
       BinaryImageInformation(
@@ -357,7 +357,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
       theImages = Backtrace.captureImages()
     }
 
-    let theCacheInfo: Backtrace.SharedCacheInfo
+    let theCacheInfo: Backtrace.SharedCacheInfo?
     if let sharedCacheInfo = sharedCacheInfo {
       theCacheInfo = sharedCacheInfo
     } else if let sharedCacheInfo = backtrace.sharedCacheInfo {
@@ -450,14 +450,14 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
       lines.append("\(n)\t\(image)")
     }
 
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-    lines.append("")
-    lines.append("Shared Cache:")
-    lines.append("")
-    lines.append("    UUID: \(hex(sharedCacheInfo.uuid))")
-    lines.append("    Base: \(hex(sharedCacheInfo.baseAddress))")
-    lines.append("  Active: \(!sharedCacheInfo.noCache)")
-    #endif
+    if let sharedCacheInfo = sharedCacheInfo {
+      lines.append("")
+      lines.append("Shared Cache:")
+      lines.append("")
+      lines.append("    UUID: \(hex(sharedCacheInfo.uuid))")
+      lines.append("    Base: \(hex(sharedCacheInfo.baseAddress))")
+      lines.append("  Active: \(!sharedCacheInfo.noCache)")
+    }
 
     return lines.joined(separator: "\n")
   }

--- a/stdlib/public/Backtracing/Utils.swift
+++ b/stdlib/public/Backtracing/Utils.swift
@@ -1,0 +1,32 @@
+//===--- Utils.swift - Utility functions ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Utility functions that are used in the backtracing library.
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+internal func hex<T: FixedWidthInteger>(_ value: T,
+                                        withPrefix: Bool = true) -> String {
+  let digits = String(value, radix: 16)
+  let padTo = value.bitWidth / 4
+  let padding = digits.count >= padTo ? "" : String(repeating: "0",
+                                                    count: padTo - digits.count)
+  let prefix = withPrefix ? "0x" : ""
+
+  return "\(prefix)\(padding)\(digits)"
+}
+
+internal func hex(_ bytes: [UInt8]) -> String {
+  return bytes.map{ hex($0, withPrefix: false) }.joined(separator: "")
+}

--- a/stdlib/public/Backtracing/get-cpu-context.S
+++ b/stdlib/public/Backtracing/get-cpu-context.S
@@ -1,0 +1,142 @@
+//===--- get-cpu-context.S - Low-level functions to capture registers -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Saves the necessary registers to an appropriate Context structure.
+//
+//===----------------------------------------------------------------------===//
+
+        // On Apple platforms, we need an extra underscore
+#if __APPLE__
+  #define FN(x) _##x
+#else
+  #define FN(x) x
+#endif
+
+        .text
+        .globl FN(_swift_get_cpu_context)
+
+// .. x86-64 ...................................................................
+
+#if defined(__x86_64__)
+        // On entry, rax contains the pointer to the x86_64_gprs
+FN(_swift_get_cpu_context):
+        movq %rax,           (%rax)
+        movq %rdx,          8(%rax)
+        movq %rcx,         16(%rax)
+        movq %rbx,         24(%rax)
+        movq %rsi,         32(%rax)
+        movq %rdi,         40(%rax)
+        movq %rbp,         48(%rax)
+        leaq 8(%rsp),      %rdx
+        movq %rdx,         56(%rax)
+        movq %r8,          64(%rax)
+        movq %r9,          72(%rax)
+        movq %r10,         80(%rax)
+        movq %r11,         88(%rax)
+        movq %r12,         96(%rax)
+        movq %r13,         104(%rax)
+        movq %r14,         112(%rax)
+        movq %r15,         120(%rax)
+        pushf
+        pop  %rdx
+        movq %rdx,         128(%rax)
+        movw %cs,          %dx
+        movw %dx,          136(%rax)
+        movw %fs,          %dx
+        movw %dx,          138(%rax)
+        movw %gs,          %dx
+        movw %dx,          140(%rax)
+        movq (%rsp),       %rdx
+        movq %rdx,         144(%rax)
+        movq $0x1fffff,    152(%rax)
+        ret
+#endif
+
+// .. i386 .....................................................................
+
+#if defined(__i386__)
+        // On entry, 8(%esp) contains the pointer to the i386_gprs
+FN(_swift_get_cpu_context):
+        push %eax
+        movl 8(%esp),  %eax
+        movl %ecx,     4(%eax)
+        movl %edx,     8(%eax)
+        movl %ebx,    12(%eax)
+        movl %esi,    16(%eax)
+        movl %edi,    20(%eax)
+        movl %ebp,    24(%eax)
+        leal 8(%esp), %edx
+        movl %edx,    28(%eax)
+        pushf
+        pop  %edx
+        movl %edx,    32(%eax)
+        movw %ss,     %dx
+        movw %dx,     36(%eax)
+        movw %cs,     %dx
+        movw %dx,     38(%eax)
+        movw %ds,     %dx
+        movw %dx,     40(%eax)
+        movw %es,     %dx
+        movw %dx,     42(%eax)
+        movw %fs,     %dx
+        movw %dx,     44(%eax)
+        movw %gs,     %dx
+        movw %dx,     46(%eax)
+        movl (%esp),  %dx
+        movl %edx,    (%eax)
+        movl $0xffff, 48(%eax)
+        popl %eax
+        ret
+#endif
+
+// .. ARM64 ....................................................................
+
+#if defined(__aarch64__)
+        .p2align 2
+        // On entry, x8 contains a pointer to the arm64_gprs
+FN(_swift_get_cpu_context):
+        stp  x0,  x1, [x8, #0x00]
+        stp  x2,  x3, [x8, #0x10]
+        stp  x4,  x5, [x8, #0x20]
+        stp  x6,  x7, [x8, #0x30]
+        stp  x8,  x9, [x8, #0x40]
+        stp x10, x11, [x8, #0x50]
+        stp x12, x13, [x8, #0x60]
+        stp x14, x15, [x8, #0x70]
+        stp x16, x17, [x8, #0x80]
+        stp x18, x19, [x8, #0x90]
+        stp x20, x21, [x8, #0xa0]
+        stp x22, x23, [x8, #0xb0]
+        stp x24, x25, [x8, #0xc0]
+        stp x26, x27, [x8, #0xd0]
+        stp x28, x29, [x8, #0xe0]
+        mov  x1, sp
+        stp x30, x1,  [x8, #0xf0]
+        str x30,      [x8, #0x100]
+        mov  x1, #0x1ffffffff
+        str  x1,      [x8, #0x108]
+        ret
+#endif
+
+// .. 32-bit ARM ...............................................................
+
+#if defined(__arm__)
+        .p2align 2
+        // On entry, r0 contains a pointer to the arm_gprs
+FN(_swift_get_cpu_context):
+        stm r0, {r0-r14}
+        str lr, [r0, #0x3c]
+        mov r1, #0xffff
+        str r1, [r0, #0x40]
+        bx  lr
+#endif
+

--- a/stdlib/public/Backtracing/get-cpu-context.asm
+++ b/stdlib/public/Backtracing/get-cpu-context.asm
@@ -1,0 +1,2 @@
+;;; Placeholder for Windows assembly code
+;;; This uses different syntax from everywhere else :-(

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -151,6 +151,12 @@ if(SWIFT_BUILD_STDLIB)
   if(SWIFT_ENABLE_EXPERIMENTAL_REFLECTION)
     add_subdirectory(Reflection)
   endif()
+
+  if(SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION)
+    add_subdirectory(Observation)
+  endif()
+
+  add_subdirectory(Backtracing)
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)

--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -21,6 +21,7 @@ set(sources
   ThreadLocalStorage.h
   UnicodeData.h
   Visibility.h
+  _SwiftBacktracing.h
   _SwiftConcurrency.h
   _SwiftDistributed.h
   _SwiftRuntime.h

--- a/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
@@ -29,7 +29,9 @@
 
 #include <CoreFoundation/CFUUID.h>
 #include <CoreFoundation/CFString.h>
+#endif
 
+#if TARGET_OS_OSX
 #include <libproc.h>
 #endif
 

--- a/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
@@ -29,10 +29,19 @@
 
 #include <CoreFoundation/CFUUID.h>
 #include <CoreFoundation/CFString.h>
+
+#if __has_include(<libproc.h>)
+#include <libproc.h>
+#else
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern int proc_name(int pid, void * buffer, uint32_t buffersize);
+#ifdef __cplusplus
+}
+#endif
 #endif
 
-#if TARGET_OS_OSX
-#include <libproc.h>
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
@@ -23,7 +23,7 @@
 #include <TargetConditionals.h>
 #endif
 
-#if TARGET_OS_OSX
+#if TARGET_OS_OSX || TARGET_OS_IPHONE
 #include <mach/machine.h>
 #include <mach/task.h>
 
@@ -76,7 +76,7 @@ struct arm_gprs {
 
 // .. Darwin specifics .........................................................
 
-#if TARGET_OS_OSX
+#if TARGET_OS_OSX || TARGET_OS_IPHONE
 
 /* Darwin thread states.  We can't import these from the system header because
    it uses all kinds of macros and the Swift importer can't cope with that.
@@ -258,7 +258,7 @@ enum {
   kCRSanitizePathKeepFile = 0x100 << 1,
 };
 
-#endif // TARGET_OS_OSX
+#endif // TARGET_OS_OSX || TARGET_OS_IPHONE
 
 #ifdef __cplusplus
 } // extern "C"

--- a/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftBacktracing.h
@@ -19,6 +19,20 @@
 
 #include <inttypes.h>
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
+#if TARGET_OS_OSX
+#include <mach/machine.h>
+#include <mach/task.h>
+
+#include <CoreFoundation/CFUUID.h>
+#include <CoreFoundation/CFString.h>
+
+#include <libproc.h>
+#endif
+
 #ifdef __cplusplus
 namespace swift {
 extern "C" {
@@ -30,6 +44,221 @@ struct CrashInfo {
   uint64_t fault_address;
   uint64_t mctx;
 };
+
+// .. Processor specifics ......................................................
+
+struct x86_64_gprs {
+  uint64_t _r[16];
+  uint64_t rflags;
+  uint16_t cs, fs, gs, _pad0;
+  uint64_t rip;
+  uint64_t valid;
+};
+
+struct i386_gprs {
+  uint32_t _r[8];
+  uint32_t eflags;
+  uint16_t segreg[6];
+  uint32_t eip;
+  uint32_t valid;
+};
+
+struct arm64_gprs {
+  uint64_t _x[32];
+  uint64_t pc;
+  uint64_t valid;
+};
+
+struct arm_gprs {
+  uint32_t _r[16];
+  uint32_t valid;
+};
+
+// .. Darwin specifics .........................................................
+
+#if TARGET_OS_OSX
+
+/* Darwin thread states.  We can't import these from the system header because
+   it uses all kinds of macros and the Swift importer can't cope with that.
+   So declare them here in a form it can understand. */
+#define ARM_THREAD_STATE64 6
+struct darwin_arm64_thread_state {
+  uint64_t _x[29];
+  uint64_t fp;
+  uint64_t lr;
+  uint64_t sp;
+  uint64_t pc;
+  uint32_t cpsr;
+  uint32_t __pad;
+};
+
+struct darwin_arm64_exception_state {
+  uint64_t far;
+  uint32_t esr;
+  uint32_t exception;
+};
+
+struct darwin_arm64_mcontext {
+  struct darwin_arm64_exception_state es;
+  struct darwin_arm64_thread_state    ss;
+  // followed by NEON state (which we don't care about)
+};
+
+#define x86_THREAD_STATE64 4
+struct darwin_x86_64_thread_state {
+  uint64_t rax;
+  uint64_t rbx;
+  uint64_t rcx;
+  uint64_t rdx;
+  uint64_t rdi;
+  uint64_t rsi;
+  uint64_t rbp;
+  uint64_t rsp;
+  uint64_t r8;
+  uint64_t r9;
+  uint64_t r10;
+  uint64_t r11;
+  uint64_t r12;
+  uint64_t r13;
+  uint64_t r14;
+  uint64_t r15;
+  uint64_t rip;
+  uint64_t rflags;
+  uint64_t cs;
+  uint64_t fs;
+  uint64_t gs;
+};
+
+struct darwin_x86_64_exception_state {
+  uint16_t trapno;
+  uint16_t cpu;
+  uint32_t err;
+  uint64_t faultvaddr;
+};
+
+struct darwin_x86_64_mcontext {
+  struct darwin_x86_64_exception_state es;
+  struct darwin_x86_64_thread_state    ss;
+  // followed by FP/AVX/AVX512 state (which we don't care about)
+};
+
+/* DANGER!  These are SPI.  They may change (or vanish) at short notice, may
+   not work how you expect, and are generally dangerous to use. */
+// ###FIXME: Remove the 0
+#if 0 && __has_include(<mach-o/dyld_process_info.h>)
+  #include <mach-o/dyld_process_info.h>
+#else
+struct dyld_process_cache_info {
+  uuid_t      cacheUUID;
+  uint64_t    cacheBaseAddress;
+  bool        noCache;
+  bool        privateCache;
+};
+typedef struct dyld_process_cache_info dyld_process_cache_info;
+typedef const struct dyld_process_info_base* dyld_process_info;
+
+extern dyld_process_info _dyld_process_info_create(task_t task, uint64_t timestamp, kern_return_t* kernelError);
+extern void  _dyld_process_info_release(dyld_process_info info);
+extern void  _dyld_process_info_retain(dyld_process_info info);
+extern void  _dyld_process_info_get_cache(dyld_process_info info, dyld_process_cache_info* cacheInfo);
+extern void _dyld_process_info_for_each_image(dyld_process_info info, void (^callback)(uint64_t machHeaderAddress, const uuid_t uuid, const char* path));
+extern void _dyld_process_info_for_each_segment(dyld_process_info info, uint64_t machHeaderAddress, void (^callback)(uint64_t segmentAddress, uint64_t segmentSize, const char* segmentName));
+#endif
+
+/* DANGER!  CoreSymbolication is a private framework.  This is all SPI. */
+// ###FIXME: Remove the 0
+struct _CSArchitecture {
+    cpu_type_t		cpu_type;
+    cpu_subtype_t	cpu_subtype;
+};
+
+typedef struct _CSArchitecture CSArchitecture;
+
+static const CSArchitecture kCSArchitectureI386 = { CPU_TYPE_I386, CPU_SUBTYPE_I386_ALL };
+static const CSArchitecture kCSArchitectureX86_64 = { CPU_TYPE_I386|CPU_ARCH_ABI64, CPU_SUBTYPE_I386_ALL };
+static const CSArchitecture kCSArchitectureArm64 =   { CPU_TYPE_ARM | CPU_ARCH_ABI64, CPU_SUBTYPE_ARM64_ALL };
+static const CSArchitecture kCSArchitectureArm64_32 =   { CPU_TYPE_ARM | CPU_ARCH_ABI64_32, CPU_SUBTYPE_ARM64_ALL };
+static const CSArchitecture kCSArchitectureArmV7K =  { CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7K };
+
+typedef struct _CSBinaryRelocationInformation {
+  mach_vm_address_t base;
+  mach_vm_address_t extent;
+  char name[17];
+} CSBinaryRelocationInformation;
+
+typedef struct _CSBinaryImageInformation {
+  mach_vm_address_t base;
+  mach_vm_address_t extent;
+  CFUUIDBytes uuid;
+  CSArchitecture arch;
+  const char *path;
+  CSBinaryRelocationInformation *relocations;
+  uint32_t relocationCount;
+  uint32_t flags;
+} CSBinaryImageInformation;
+
+typedef uint64_t CSMachineTime;
+
+static const CSMachineTime kCSBeginningOfTime = 0;
+static const CSMachineTime kCSEndOfTime = INT64_MAX;
+static const CSMachineTime kCSNow = INT64_MAX + 1ULL;
+static const CSMachineTime kCSAllTimes = INT64_MAX + 2ULL;
+
+struct _CSTypeRef {
+  uintptr_t _opaque_1;
+  uintptr_t _opaque_2;
+};
+
+typedef struct _CSTypeRef CSTypeRef;
+
+typedef CSTypeRef CSNullRef;
+typedef CSTypeRef CSSymbolicatorRef;
+typedef CSTypeRef CSSymbolOwnerRef;
+typedef CSTypeRef CSSymbolRef;
+typedef CSTypeRef CSSourceInfoRef;
+
+static const CSNullRef kCSNull = { 0, 0 };
+
+typedef void (^CSSymbolOwnerIterator)(CSSymbolOwnerRef owner);
+typedef void (^CSStackFrameIterator)(CSSymbolRef symbol, CSSourceInfoRef info);
+
+typedef struct _CSNotificationData {
+    CSSymbolicatorRef symbolicator;
+    union {
+        struct Ping {
+            uint32_t value;
+        } ping;
+
+        struct DyldLoad {
+            CSSymbolOwnerRef symbolOwner;
+        } dyldLoad;
+
+        struct DyldUnload {
+            CSSymbolOwnerRef symbolOwner;
+        } dyldUnload;
+    } u;
+} CSNotificationData;
+
+typedef void (^CSNotificationBlock)(uint32_t type, CSNotificationData data);
+
+struct _CSRange {
+  mach_vm_address_t	location;
+  mach_vm_size_t	length;
+};
+
+typedef struct _CSRange CSRange;
+
+/* DANGER! This is also SPI */
+enum {
+  kCRSanitizePathGlobLocalHomeDirectories = 1,
+  kCRSanitizePathGlobLocalVolumes = 2,
+  kCRSanitizePathGlobAllTypes = 0xff,
+
+  kCRSanitizePathNormalize = 0x100 << 0,
+  kCRSanitizePathKeepFile = 0x100 << 1,
+};
+
+#endif // TARGET_OS_OSX
 
 #ifdef __cplusplus
 } // extern "C"

--- a/stdlib/public/SwiftShims/swift/shims/module.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/module.modulemap
@@ -26,6 +26,10 @@ module _SwiftConcurrencyShims {
   header "_SwiftConcurrency.h"
 }
 
+module _SwiftBacktracingShims {
+  header "_SwiftBacktracing.h"
+}
+
 module SwiftOverlayShims {
   header "LibcOverlayShims.h"
   export *

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -153,7 +153,7 @@ suspend_other_threads()
       continue;
 
     // Ignore the results of these two; if they fail there's nothing we can do
-    (void)thread_resume(threads[n]);
+    (void)thread_suspend(threads[n]);
     (void)mach_port_deallocate(mach_task_self(), threads[n]);
   }
 

--- a/test/Backtracing/BacktraceWithLimit.swift
+++ b/test/Backtracing/BacktraceWithLimit.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/BacktraceWithLimit
+// RUN: %target-codesign %t/BacktraceWithLimit
+// RUN: %target-run %t/BacktraceWithLimit | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+import _Backtracing
+
+func doFrames(_ count: Int) {
+  if count <= 0 {
+    let backtrace = try! Backtrace.capture(limit: 10, top: 0)
+
+    print(backtrace)
+  } else {
+    doFrames(count - 1)
+  }
+}
+
+@main
+struct BacktraceWithLimit {
+  static func main() {
+    // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 1{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 2{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 3{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 4{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 5{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 6{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 7{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 8{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 9{{[ \t]+}}...
+    doFrames(1000)
+
+    print("")
+
+    // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 1{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 2{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 3{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 4{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    doFrames(5)
+  }
+}

--- a/test/Backtracing/BacktraceWithLimitAndTop.swift
+++ b/test/Backtracing/BacktraceWithLimitAndTop.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/BacktraceWithLimitAndTop
+// RUN: %target-codesign %t/BacktraceWithLimitAndTop
+// RUN: %target-run %t/BacktraceWithLimitAndTop | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+import _Backtracing
+
+func doFrames(_ count: Int, limit: Int, top: Int) {
+  if count <= 0 {
+    let backtrace = try! Backtrace.capture(limit: limit, top: top)
+
+    print(backtrace)
+  } else {
+    doFrames(count - 1, limit: limit, top: top)
+  }
+}
+
+@main
+struct BacktraceWithTop {
+  static func main() {
+    // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 1{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 2{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 3{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 4{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 5{{[ \t]+}}...
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    doFrames(1000, limit: 10, top: 4)
+
+    print("")
+
+    // CHECK:      0{{[ \t]+}}...
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: {{[0-9]+[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    doFrames(1000, limit: 10, top: 10)
+
+    print("")
+
+    // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 1{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 2{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 3{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 4{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    // CHECK-NEXT: 5{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+    doFrames(6, limit: 30, top: 4)
+  }
+}

--- a/test/Backtracing/SimpleAsyncBacktrace.swift
+++ b/test/Backtracing/SimpleAsyncBacktrace.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -g -parse-as-library -Onone -o %t/SimpleAsyncBacktrace
+// RUN: %target-codesign %t/SimpleAsyncBacktrace
+// RUN: %target-run %t/SimpleAsyncBacktrace | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=iOS || OS=watchOS || OS=tvOS
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import _Backtracing
+
+@available(SwiftStdlib 5.1, *)
+func level1() async {
+  await level2()
+}
+
+@available(SwiftStdlib 5.1, *)
+func level2() async {
+  level3()
+}
+
+@available(SwiftStdlib 5.1, *)
+func level3() {
+  level4()
+}
+
+@available(SwiftStdlib 5.1, *)
+func level4() {
+  level5()
+}
+
+@available(SwiftStdlib 5.1, *)
+func level5() {
+  let backtrace = try! Backtrace.capture()
+
+  // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 1{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 2{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 3{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 4{{[ \t]+}}0x{{[0-9a-f]+}} [async]
+  // CHECK-NEXT: 5{{[ \t]+}}0x{{[0-9a-f]+}} [async]
+
+  print(backtrace)
+}
+
+@available(SwiftStdlib 5.1, *)
+@main
+struct SimpleAsyncBacktrace {
+  static func main() async {
+    await level1()
+  }
+}

--- a/test/Backtracing/SimpleBacktrace.swift
+++ b/test/Backtracing/SimpleBacktrace.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Xfrontend -parse-as-library -Onone -o %t/SimpleBacktrace
+// RUN: %target-codesign %t/SimpleBacktrace
+// RUN: %target-run %t/SimpleBacktrace | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=iOS || OS=watchOS || OS=tvOS
+
+import _Backtracing
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  let backtrace = try! Backtrace.capture()
+
+  // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 1{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 2{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 3{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 4{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+  // CHECK-NEXT: 5{{[ \t]+}}0x{{[0-9a-f]+}} [ra]
+
+  print(backtrace)
+}
+
+@main
+struct SimpleBacktrace {
+  static func main() {
+    level1()
+  }
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1044,7 +1044,8 @@ if run_vendor == 'apple':
                         "swiftStdlibCollectionUnittest",
                         "swiftSwiftPrivateLibcExtras", "swiftSwiftPrivate",
                         "swiftDarwin", "swiftSwiftPrivateThreadExtras",
-                        "swiftSwiftOnoneSupport", "swift_Concurrency"]:
+                        "swiftSwiftOnoneSupport", "swift_Concurrency",
+                        "swift_Backtracing"]:
             swift_execution_tests_extra_flags += ' -Xlinker -l%s'% library
 
         swift_native_clang_tools_path = lit_config.params.get('swift_native_clang_tools_path', None)
@@ -1790,6 +1791,13 @@ concurrency_module = os.path.join(stdlib_dir, "_Concurrency.swiftmodule",
 config.substitutions.append(('%concurrency_module', concurrency_module))
 config.substitutions.append(('%/concurrency_module',
                              '/'.join(os.path.normpath(concurrency_module).split(os.sep))))
+
+# Add 'backtracing_module' as the path to the _Backtracing .swiftmodule file
+backtracing_module = os.path.join(stdlib_dir, "_Backtracing.swiftmodule",
+                                   target_specific_module_triple + ".swiftmodule")
+config.substitutions.append(('%backtracing_module', backtracing_module))
+config.substitutions.append(('%/backtracing_module',
+                             '/'.join(os.path.normpath(backtracing_module).split(os.sep))))
 
 # Add 'distributed_module' as the path to the Distributed .swiftmodule file
 distributed_module = os.path.join(stdlib_dir, "Distributed.swiftmodule",


### PR DESCRIPTION
Adds a new swift_Backtracing library, with a corresponding _Backtracing module, to the build.  Also add some tests.

This is not public API at this point, but will be used by the external backtracing program, `swift-backtrace`.

rdar://104336548
