### PR TITLE
fix binary search for symbol.value == nextValue == address

### DIFF
--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -1157,7 +1157,7 @@ struct ElfSymbolTable<SomeElfTraits: ElfTraits>: ElfSymbolTableProtocol {
         nextValue = _symbols[mid + 1].value
       }
 
-      if symbol.value <= address && nextValue > address {
+      if symbol.value <= address && nextValue >= address {
         var ndx = mid
         while ndx > 0 && _symbols[ndx - 1].value == address {
           ndx -= 1


### PR DESCRIPTION
In the situation that `address == symbol.value == nextValue`, we'd loop forever because the branch `if symbol.value <= address && nextValue >= address` wouldn't be taken (and neither would any others).